### PR TITLE
fix: correct command placement and add -i=false to all CLI commands

### DIFF
--- a/skills/zeabur-deployment-logs/SKILL.md
+++ b/skills/zeabur-deployment-logs/SKILL.md
@@ -17,7 +17,7 @@ npx zeabur@latest context set project --id <project-id> -i=false -y
 npx zeabur@latest service list -i=false
 
 # 3. View logs (auto-selects single environment)
-npx zeabur@latest deployment log --service-id <service-id> -t runtime 2>&1 | tail -50
+npx zeabur@latest deployment log --service-id <service-id> -t runtime -i=false 2>&1 | tail -50
 ```
 
 Output will show: `INFO Only one environment in current project, select <production> automatically`
@@ -63,7 +63,8 @@ npx zeabur@latest deployment log \
 npx zeabur@latest deployment log \
   --service-id <id> \
   --env-id <env-id> \
-  -w
+  -w \
+  -i=false
 ```
 
 ## Tips

--- a/skills/zeabur-migration/SKILL.md
+++ b/skills/zeabur-migration/SKILL.md
@@ -22,11 +22,14 @@ App expects migrations to run separately, but no migrator service exists.
 ### Option A: Add migration to API startup
 
 ```yaml
-# In api service
-command:
-  - /bin/sh
-  - -c
-  - "python manage.py wait_for_db && python manage.py migrate && exec ./entrypoint.sh"
+# In api service — command MUST be inside source
+spec:
+  source:
+    image: myapp:latest
+    command:
+      - /bin/sh
+      - -c
+      - "python manage.py wait_for_db && python manage.py migrate && exec ./entrypoint.sh"
 ```
 
 ### Option B: Add migrator service

--- a/skills/zeabur-project-create/SKILL.md
+++ b/skills/zeabur-project-create/SKILL.md
@@ -46,11 +46,13 @@ npx zeabur@latest context set project --id <project-id> -i=false -y
 ## Deploy Template to Project
 
 ```bash
-# Deploy template file to specific project
-npx zeabur@latest template deploy -f <template-file> --project-id <project-id>
+# Deploy template file to specific project (non-interactive)
+npx zeabur@latest template deploy -i=false \
+  -f <template-file> \
+  --project-id <project-id> \
+  --var PUBLIC_DOMAIN=myapp \
+  --var KEY=value
 ```
-
-**Note:** Template deploy requires interactive mode for variable input (domain, API keys, etc.)
 
 ## Full Workflow Example
 
@@ -63,8 +65,8 @@ PROJECT_ID=$(npx zeabur@latest project list -i=false 2>/dev/null | grep "wrenai-
 echo "Project ID: $PROJECT_ID"
 echo "Dashboard: https://zeabur.com/projects/$PROJECT_ID"
 
-# 3. Deploy template (interactive for variables)
-npx zeabur@latest template deploy -f template.yml --project-id $PROJECT_ID
+# 3. Deploy template (non-interactive)
+npx zeabur@latest template deploy -i=false -f template.yml --project-id $PROJECT_ID --var PUBLIC_DOMAIN=myapp
 
 # 4. Set context for subsequent commands
 npx zeabur@latest context set project --id $PROJECT_ID -i=false -y

--- a/skills/zeabur-restart/SKILL.md
+++ b/skills/zeabur-restart/SKILL.md
@@ -19,7 +19,7 @@ npx zeabur@latest service restart --id <service-id> --env-id <env-id> -y
 ## Extract env-id from Logs
 
 ```bash
-npx zeabur@latest deployment log --service-id <id> 2>/dev/null | \
+npx zeabur@latest deployment log --service-id <id> -i=false 2>/dev/null | \
   grep -o "environment-[a-f0-9]*" | head -1
 # Returns: environment-696f996ecc2bf23f5a3d7aaa
 # Use: 696f996ecc2bf23f5a3d7aaa as env-id
@@ -29,7 +29,7 @@ npx zeabur@latest deployment log --service-id <id> 2>/dev/null | \
 
 ```bash
 # Get env-id
-ENV_ID=$(npx zeabur@latest deployment log --service-id <service-id> 2>/dev/null | grep -o "environment-[a-f0-9]*" | head -1 | cut -d'-' -f2)
+ENV_ID=$(npx zeabur@latest deployment log --service-id <service-id> -i=false 2>/dev/null | grep -o "environment-[a-f0-9]*" | head -1 | cut -d'-' -f2)
 
 # Restart
 npx zeabur@latest service restart --id <service-id> --env-id $ENV_ID -y

--- a/skills/zeabur-startup-order/SKILL.md
+++ b/skills/zeabur-startup-order/SKILL.md
@@ -19,21 +19,28 @@ Service starts before dependency (DB/Redis) is ready.
 
 ## Fix
 
-Add wait logic to service command:
+Add wait logic to service command (command MUST be inside `source`):
 
 ```yaml
-command:
-  - /bin/sh
-  - -c
-  - "python manage.py wait_for_db && exec ./entrypoint.sh"
+# Python example
+spec:
+  source:
+    image: myapp:latest
+    command:
+      - /bin/sh
+      - -c
+      - "python manage.py wait_for_db && exec ./entrypoint.sh"
 ```
 
 Or for Node.js:
 ```yaml
-command:
-  - /bin/sh
-  - -c
-  - "until nc -z postgres 5432; do sleep 1; done && node server.js"
+spec:
+  source:
+    image: myapp:latest
+    command:
+      - /bin/sh
+      - -c
+      - "until nc -z postgres 5432; do sleep 1; done && node server.js"
 ```
 
 ## Quick Fix

--- a/skills/zeabur-template-backup/SKILL.md
+++ b/skills/zeabur-template-backup/SKILL.md
@@ -16,7 +16,7 @@ Backup a Zeabur template to the local git repository with standardized naming.
 ## Repository Location
 
 ```
-/Users/can/Documents/github/zeabur-template/
+/Users/can/Documents/zeabur/zeabur-template/
 ```
 
 ## Naming Convention
@@ -84,7 +84,7 @@ Using browser automation:
 
 ```bash
 # Create directory
-mkdir -p /Users/can/Documents/github/zeabur-template/{service-name}
+mkdir -p /Users/can/Documents/zeabur/zeabur-template/{service-name}
 
 # Save YAML with naming pattern
 # zeabur-template-{service-name}-{TEMPLATE_CODE}.yaml
@@ -94,9 +94,7 @@ mkdir -p /Users/can/Documents/github/zeabur-template/{service-name}
 
 ```bash
 git add {service-name}/
-git commit -m "feat({service-name}): add {Template Name} template
-
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+git commit -m "feat({service-name}): add {Template Name} template"
 ```
 
 ### 6. Push (if requested)

--- a/skills/zeabur-template-deploy/skill.md
+++ b/skills/zeabur-template-deploy/skill.md
@@ -5,16 +5,13 @@ description: Use when deploying Zeabur templates via CLI. Use when automating te
 
 # Zeabur Template Deploy
 
-Deploy Zeabur templates via CLI with support for non-interactive mode.
+Deploy Zeabur templates via CLI. **Always use non-interactive mode (`-i=false`) in CLI automation.**
 
 ## Basic Usage
 
 ```bash
-# Interactive mode (default)
-zeabur template deploy -f template.yaml
-
-# Non-interactive mode
-zeabur template deploy -i=false \
+# Non-interactive mode (required for CLI automation)
+npx zeabur@latest template deploy -i=false \
   -f template.yaml \
   --project-id <project-id> \
   --var KEY1=value1 \
@@ -29,7 +26,7 @@ zeabur template deploy -i=false \
 | `--project-id` | Project ID to deploy on |
 | `--var` | Template variables (repeatable, e.g. `--var KEY=value`) |
 | `--skip-validation` | Skip template validation |
-| `-i=false` | Non-interactive mode |
+| `-i=false` | Non-interactive mode (always use this) |
 
 ## Non-Interactive Mode
 
@@ -48,19 +45,19 @@ Error: missing required variables in non-interactive mode:
 ### Deploy with Variables
 
 ```bash
-zeabur template deploy -i=false \
+npx zeabur@latest template deploy -i=false \
   -f https://example.com/template.yaml \
   --project-id abc123 \
   --var PUBLIC_DOMAIN=myapp \
   --var ADMIN_EMAIL=admin@example.com
 ```
 
-### Mixed Mode (Interactive + Pre-filled)
+### Deploy Local File
 
 ```bash
-# Pre-fill some variables, prompt for the rest
-zeabur template deploy \
-  -f template.yaml \
+npx zeabur@latest template deploy -i=false \
+  -f zeabur-template-myapp.yaml \
+  --project-id abc123 \
   --var PUBLIC_DOMAIN=myapp
 ```
 
@@ -85,6 +82,7 @@ spec:
 
 | Issue | Solution |
 |-------|----------|
+| Interactive prompt hangs | Always use `-i=false` with `--project-id` and `--var` flags |
 | Missing variables error | Add all required `--var` flags |
 | Variable with `${REF}` | Use literal value or set in Dashboard after deploy |
 | DOMAIN type validation | Domain availability checked automatically |


### PR DESCRIPTION
## Summary

- **CRITICAL**: Document that `command` must be inside `source` (alongside `image`), NOT at `spec` level
- Add `command` + `configs` example to template skeleton
- Standardize all CLI commands to `npx zeabur@latest` (was bare `zeabur` in template-deploy)
- Add `-i=false` to all commands missing it (deployment-logs, restart, project-create, template-deploy)
- Remove misleading "interactive mode required" note from project-create
- Fix template-backup repo path and remove hardcoded Co-Authored-By

## Context

Discovered during a real nanobot template deployment where `command` at `spec` level was silently ignored — container used default CMD and crash-looped. Moving `command` inside `source` fixed it immediately.

## Files Changed (8)

| Skill | Change |
|-------|--------|
| `zeabur-template` | Add `command` placement warning + correct skeleton |
| `zeabur-template-deploy` | Use `npx zeabur@latest`, lead with non-interactive mode |
| `zeabur-migration` | Show `command` inside `source` with full context |
| `zeabur-startup-order` | Show `command` inside `source` with full context |
| `zeabur-project-create` | Add `-i=false` to deploy commands |
| `zeabur-deployment-logs` | Add `-i=false` to log commands |
| `zeabur-restart` | Add `-i=false` to log commands |
| `zeabur-template-backup` | Fix repo path, remove hardcoded Co-Authored-By |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment commands to use non-interactive mode with the `-i=false` flag
  * Clarified variable passing via command flags instead of interactive prompts
  * Updated configuration structure guidance and examples across multiple deployment topics
  * Enhanced troubleshooting guidance for template deployment
  * Revised examples and paths for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->