### PR TITLE
feat: improve skill descriptions with trigger phrases

### DIFF
--- a/skills/zeabur-deployment-logs/SKILL.md
+++ b/skills/zeabur-deployment-logs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-deployment-logs
-description: Use when viewing service runtime or build logs.
+description: Use when viewing service runtime or build logs. Use when user says "show logs", "why did deploy fail", "check build output", or "debug runtime error".
 ---
 
 # Zeabur Deployment Logs
@@ -35,6 +35,6 @@ npx zeabur@latest deployment log --service-id <id> -w -i=false
 | Tip | Details |
 |-----|---------|
 | Use `tail -50` | Logs can be verbose, pipe to tail for recent entries |
-| Use `grep` to filter | `... 2>&1 \| grep -i "error\|started\|ready"` |
+| Use `grep` to filter | `... 2>&1 | grep -i "error\|started\|ready"` |
 | Note singular | `deployment log` not `deployment logs` |
 | Check service status | Look for `SERVER STARTED`, `Ready`, `listening` |

--- a/skills/zeabur-domain-url/SKILL.md
+++ b/skills/zeabur-domain-url/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-domain-url
-description: Use when services need public URL for redirects or CORS. Use when WEB_URL or similar has trailing slash issues.
+description: Use when services need public URL for redirects or CORS. Use when WEB_URL or similar has trailing slash issues. Use when user reports "redirect goes to wrong URL", "CORS error", or "trailing slash problem".
 ---
 
 # Zeabur Domain URL Configuration

--- a/skills/zeabur-project-create/SKILL.md
+++ b/skills/zeabur-project-create/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-project-create
-description: Use when creating a new Zeabur project. Use when deploying templates to a new project.
+description: Use when creating a new Zeabur project. Use when deploying templates to a new project. Use when user says "create project", "new project", or "set up a new environment".
 ---
 
 # Zeabur Project Create

--- a/skills/zeabur-restart/SKILL.md
+++ b/skills/zeabur-restart/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-restart
-description: Use when restarting a Zeabur service.
+description: Use when restarting a Zeabur service. Use when user says "restart", "reboot service", or "service is stuck/frozen".
 ---
 
 # Zeabur Service Restart

--- a/skills/zeabur-server-catalog/SKILL.md
+++ b/skills/zeabur-server-catalog/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-server-catalog
-description: Use when browsing available dedicated server options. Use when user asks what servers are available to rent.
+description: Use when browsing available dedicated server options. Use when user asks "what servers are available", "show server prices", or "compare server plans". Do NOT use for listing owned servers (use zeabur-server-list instead).
 ---
 
 # Zeabur Server Catalog

--- a/skills/zeabur-server-list/SKILL.md
+++ b/skills/zeabur-server-list/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-server-list
-description: Use when listing dedicated servers. Use when checking server status, IP, or provider info. Use when SSH into a server.
+description: Use when listing dedicated servers. Use when checking server status, IP, or provider info. Use when user says "show my servers", "SSH into server", or "check server status". Do NOT use for browsing purchasable servers (use zeabur-server-catalog instead).
 ---
 
 # Zeabur Server List & Get

--- a/skills/zeabur-service-list/SKILL.md
+++ b/skills/zeabur-service-list/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-service-list
-description: Use when needing service IDs for other commands. Use when checking what services exist in a project.
+description: Use when needing service IDs for other commands. Use when checking what services exist in a project. Use when user says "list services", "what's running", or "show my services".
 ---
 
 # Zeabur Service List

--- a/skills/zeabur-template-backup/SKILL.md
+++ b/skills/zeabur-template-backup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-template-backup
-description: Use when backing up a Zeabur template to git. Use when user provides a Zeabur template URL like zeabur.com/templates/XXXXXX.
+description: Use when backing up a Zeabur template to git. Use when user provides a Zeabur template URL like zeabur.com/templates/XXXXXX. Use when user says "save this template", "backup template", or "download template YAML".
 ---
 
 # Zeabur Template Backup

--- a/skills/zeabur-template-deploy/skill.md
+++ b/skills/zeabur-template-deploy/skill.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-template-deploy
-description: Use when deploying Zeabur templates via CLI. Use when automating template deployments in non-interactive mode.
+description: Use when deploying Zeabur templates via CLI. Use when automating template deployments in non-interactive mode. Use when user says "deploy template", "install template", or provides a template YAML file to deploy.
 ---
 
 # Zeabur Template Deploy

--- a/skills/zeabur-template/SKILL.md
+++ b/skills/zeabur-template/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-template
-description: Use when creating, editing, validating, or troubleshooting a Zeabur template YAML. Use when converting docker-compose to Zeabur template.
+description: Use when creating, editing, validating, or troubleshooting a Zeabur template YAML. Use when converting docker-compose to Zeabur template. Do NOT use for deploying templates (use zeabur-template-deploy instead).
 ---
 
 # Zeabur Template Knowledge Base

--- a/skills/zeabur-update-service/SKILL.md
+++ b/skills/zeabur-update-service/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-update-service
-description: Use when modifying service config without full redeploy. Use when updating env vars and restarting single service.
+description: Use when modifying service config without full redeploy. Use when updating env vars and restarting single service. Use when user says "change env var", "update config", or "fix variable without redeploying".
 ---
 
 # Zeabur Update Service Without Redeploy

--- a/skills/zeabur-variables/SKILL.md
+++ b/skills/zeabur-variables/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-variables
-description: Use when managing Zeabur environment variables via CLI. Use when variables are empty or SERVICE_NOT_FOUND errors.
+description: Use when managing Zeabur environment variables via CLI. Use when variables are empty or SERVICE_NOT_FOUND errors. Use when user says "set env var", "add variable", or "why is my variable empty".
 ---
 
 # Zeabur Variables Management


### PR DESCRIPTION
## Summary
- Add user-facing trigger phrases to 11 skill descriptions (e.g. "show logs", "restart", "create project") for better discoverability
- Add negative triggers to prevent mismatches between similar skills (e.g. `server-catalog` vs `server-list`, `template` vs `template-deploy`)
- Fix unnecessary pipe escape in `zeabur-deployment-logs`

## Test plan
- [ ] Verify skills trigger correctly on relevant user queries
- [ ] Verify negative triggers prevent cross-triggering between similar skills
- [ ] Confirm all descriptions stay under 1024 character limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced skill descriptions across all deployment automation tools with expanded usage scenarios and trigger phrases, helping users understand when each skill is most appropriate.
  * Added clarifications distinguishing between related skills and guiding users to the most relevant tool for their specific task.

* **Bug Fixes**
  * Fixed shell command syntax in deployment logs guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->