### PR TITLE
feat: require project identification before deploy

### DIFF
--- a/skills/zeabur-deploy/SKILL.md
+++ b/skills/zeabur-deploy/SKILL.md
@@ -15,8 +15,8 @@ Before using this skill, you must first determine which Zeabur project to deploy
 npx zeabur@latest project list -i=false --json
 ```
 
-- If projects exist, ask the user which one to use.
-- If the list is empty, use the `zeabur-project-create` skill to create a project first.
+- When projects exist, ask the user which one to use.
+- For an empty list, use the `zeabur-project-create` skill to create a project first.
 
 **Do not proceed with deployment until the target project is confirmed.**
 


### PR DESCRIPTION
## Summary
- Add a **Prerequisites** section to `zeabur-deploy` skill requiring the agent to identify the target project before deploying (via `project list --json`, then ask user)
- Remove inline `project create` examples from the deploy skill — delegate to `zeabur-project-create` skill instead
- Add tip: after successful deployment, offer to save Project ID and Service ID to the project's `CLAUDE.md` or `README.md` so future conversations can skip the prompt

## Test plan
- [ ] Verify the deploy skill triggers project identification before proceeding
- [ ] Verify empty project list redirects to `zeabur-project-create` skill
- [ ] Verify post-deploy tip about saving IDs appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a prerequisites section requiring users to identify and confirm a target Zeabur project before deploying
  * Clarified Git-based deployment now requires a known Project ID (no implicit project creation)
  * Updated direct-deploy guidance to recommend saving Project and Service IDs after deployment to skip future prompts and simplified related references
<!-- end of auto-generated comment: release notes by coderabbit.ai -->