### PR TITLE
fix: remove deprecated region codes and --create flag

### DIFF
--- a/skills/zeabur-deploy/SKILL.md
+++ b/skills/zeabur-deploy/SKILL.md
@@ -37,10 +37,10 @@ Deploy the current local directory to Zeabur with one command:
 
 ```bash
 # Deploy current directory (interactive — will prompt for project/service)
-npx zeabur@latest deploy
+npx zeabur@latest deploy --json
 
 # Deploy to an existing service
-npx zeabur@latest deploy --service-id <service-id> --environment-id <environment-id>
+npx zeabur@latest deploy --json --service-id <service-id> --environment-id <environment-id>
 ```
 
 ### Flags
@@ -51,6 +51,7 @@ npx zeabur@latest deploy --service-id <service-id> --environment-id <environment
 | `--service-id` | Service ID to redeploy on (for updating existing service) |
 | `--environment-id` | Environment ID to redeploy on |
 | `--domain` | Bind a domain (e.g. `myapp.zeabur.app`) |
+| `--json` | Output in JSON format (always use this) |
 | `-i=false` | Non-interactive mode |
 
 > **Note:** Do NOT use `--create`, `-r`, or `--region` flags with deploy commands. If the user needs to create a new project or select a region, use the `zeabur-project-create` skill first.
@@ -62,7 +63,7 @@ npx zeabur@latest deploy --service-id <service-id> --environment-id <environment
 cd /path/to/project
 
 # 2. Deploy directly
-npx zeabur@latest deploy
+npx zeabur@latest deploy --json
 ```
 
 No Git repository, no GitHub, no extra steps needed. If no project exists yet, use the `zeabur-project-create` skill to create one first.
@@ -76,17 +77,17 @@ If the user explicitly wants Git-based deployment (e.g. for CI/CD, auto-redeploy
 
 ```bash
 # Interactive mode — prompts for project, repo, and branch selection
-npx zeabur@latest service deploy --template GIT
+npx zeabur@latest service deploy --json --template GIT
 
 # Non-interactive mode — required parameters only
-npx zeabur@latest service deploy -i=false \
+npx zeabur@latest service deploy --json -i=false \
   --project-id <project-id> \
   --template GIT \
   --repo-id <repo-id> \
   --branch-name <branch>
 
 # With optional service name
-npx zeabur@latest service deploy -i=false \
+npx zeabur@latest service deploy --json -i=false \
   --project-id <project-id> \
   --template GIT \
   --repo-id <repo-id> \
@@ -118,7 +119,7 @@ gh repo create my-app --public --source=. --push
 REPO_ID=$(gh api repos/OWNER/my-app --jq .id)
 
 # 3. Deploy from GitHub (PROJECT_ID must be known beforehand — see Prerequisites)
-npx zeabur@latest service deploy -i=false \
+npx zeabur@latest service deploy --json -i=false \
   --project-id $PROJECT_ID \
   --template GIT \
   --repo-id $REPO_ID \
@@ -128,7 +129,7 @@ npx zeabur@latest service deploy -i=false \
 **Interactive (simpler, will prompt for repo and branch):**
 
 ```bash
-npx zeabur@latest service deploy --template GIT
+npx zeabur@latest service deploy --json --template GIT
 ```
 
 After deployment, Zeabur will auto-redeploy on every push to the selected branch.

--- a/skills/zeabur-project-create/SKILL.md
+++ b/skills/zeabur-project-create/SKILL.md
@@ -14,7 +14,7 @@ description: Use when creating a new Zeabur project. Use when deploying template
 **Step 1 — List the user's servers:**
 
 ```bash
-npx zeabur@latest server list -i=false
+npx zeabur@latest server list -i=false --json
 ```
 
 **Step 2 — Use the server ID with `server-` prefix as the region:**
@@ -29,24 +29,21 @@ The region code format is `server-<server-id>`, where `<server-id>` comes from t
 
 ```bash
 # Create project with name and region (region must be server-<server-id>)
-npx zeabur@latest project create -n "<project-name>" -r "server-<server-id>" -i=false
+npx zeabur@latest project create -n "<project-name>" -r "server-<server-id>" -i=false --json
 ```
 
 ## Get Project ID
 
 ```bash
-# List projects and find ID
-npx zeabur@latest project list -i=false 2>/dev/null | grep "<project-name>"
-
-# Extract ID (first column, strip ANSI codes)
-PROJECT_ID=$(npx zeabur@latest project list -i=false 2>/dev/null | grep "<project-name>" | awk '{print $1}' | sed 's/\x1b\[[0-9;]*m//g')
+# List projects as JSON and extract project ID by name
+PROJECT_ID=$(npx zeabur@latest project list -i=false --json | jq -r '.[] | select(.name == "<project-name>") | ._id')
 ```
 
 ## Deploy Template to Project
 
 ```bash
 # Deploy template file to specific project (non-interactive)
-npx zeabur@latest template deploy -i=false \
+npx zeabur@latest template deploy -i=false --json \
   -f <template-file> \
   --project-id <project-id> \
   --var PUBLIC_DOMAIN=myapp \
@@ -57,18 +54,18 @@ npx zeabur@latest template deploy -i=false \
 
 ```bash
 # 1. Find server ID
-npx zeabur@latest server list -i=false
+npx zeabur@latest server list -i=false --json
 
 # 2. Create project (use server-<id> from step 1)
-npx zeabur@latest project create -n "wrenai-prod" -r "server-<server-id>" -i=false
+npx zeabur@latest project create -n "wrenai-prod" -r "server-<server-id>" -i=false --json
 
 # 3. Get project ID
-PROJECT_ID=$(npx zeabur@latest project list -i=false 2>/dev/null | grep "wrenai-prod" | awk '{print $1}' | sed 's/\x1b\[[0-9;]*m//g')
+PROJECT_ID=$(npx zeabur@latest project list -i=false --json | jq -r '.[] | select(.name == "wrenai-prod") | ._id')
 echo "Project ID: $PROJECT_ID"
 echo "Dashboard: https://zeabur.com/projects/$PROJECT_ID"
 
 # 4. Deploy template (non-interactive)
-npx zeabur@latest template deploy -i=false -f template.yml --project-id $PROJECT_ID --var PUBLIC_DOMAIN=myapp
+npx zeabur@latest template deploy -i=false --json -f template.yml --project-id $PROJECT_ID --var PUBLIC_DOMAIN=myapp
 ```
 
 ## See Also


### PR DESCRIPTION
## Summary
- Remove `--create` and `--region` flag usage from `zeabur-deploy` skill, redirecting users to `zeabur-project-create` skill instead
- Remove deprecated region codes (`hnd1`, `tpe1`) from `zeabur-project-create` skill
- Region must now always be derived from `server list` using `server-<server-id>` format

## Test plan
- [ ] Verify deploy skill no longer references `--create`, `-r`, or `--region`
- [ ] Verify project-create skill no longer contains hardcoded region codes like `hnd1`
- [ ] Verify project-create workflow guides users to check `server list` first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Made deployment CLI examples JSON-centric (use --json) for Direct and Git deploy flows.
  * Clarified command restrictions: avoid legacy flags for project/region creation; use project-create flow instead.
  * Reorganized project creation to a server-first workflow and added guidance when no servers exist.
  * Noted templates that require dedicated servers and steps to recreate projects with server-derived regions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->