### PR TITLE
feat: add zeabur-project-delete skill

### DIFF
--- a/skills/zeabur-project-delete/SKILL.md
+++ b/skills/zeabur-project-delete/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: zeabur-project-delete
+description: Use when deleting a Zeabur project. Use when user says "delete project", "remove project", or "clean up project". Use when tearing down test or temporary projects. Always confirm project name and ID with the user before deleting.
+---
+
+# Zeabur Project Delete
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+Deleting a project removes all services, deployments, and data in it. This is irreversible — always confirm with the user before proceeding.
+
+## Safety First
+
+Before deleting:
+
+1. **List projects** so the user can verify the target
+2. **Show the project name and ID** and ask for explicit confirmation
+3. Only then run the delete command
+
+Never batch-delete more than one project without confirming each one.
+
+## Delete by ID
+
+```bash
+npx zeabur@latest project delete -i=false --id <project-id> -y
+```
+
+## Delete by Name
+
+```bash
+npx zeabur@latest project delete -i=false -n "<project-name>" -y
+```
+
+## Find Project ID
+
+```bash
+# List all projects
+npx zeabur@latest project list -i=false
+
+# Filter by name (strip ANSI codes)
+npx zeabur@latest project list -i=false 2>/dev/null | grep "<project-name>"
+```
+
+## Workflow
+
+```bash
+# 1. List projects to find the target
+npx zeabur@latest project list -i=false
+
+# 2. Confirm with user: "Delete <project-name> (<project-id>)?"
+
+# 3. Delete
+npx zeabur@latest project delete -i=false --id <project-id> -y
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--id` | Project ID to delete |
+| `-n, --name` | Project name to delete |
+| `-y, --yes` | Skip confirmation prompt |
+| `-i=false` | Non-interactive mode (always use this) |
+
+## See Also
+
+- `zeabur-project-create` — create a new project
+- `zeabur-service-list` — check what services exist before deleting a project


### PR DESCRIPTION
## Summary

- Add `zeabur-project-delete` skill for deleting Zeabur projects via CLI
- Uses correct `--id` flag (not `--project-id`) with safety-first workflow (list → confirm → delete)

## Test plan

- [ ] Verify skill triggers on "delete project" prompts
- [ ] Verify `--id` and `-n` flags work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a step-by-step guide for safely deleting Zeabur projects via CLI: list projects, display name and ID, require explicit confirmation, and perform deletion.
  * Includes two deletion methods (by ID or by name), helpers to locate a project ID, a concrete workflow example, a flags table (--id, -n/--name, -y/--yes, -i=false for non-interactive), and links to related project-management guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->