### PR TITLE
docs(zeabur-template): add post-deployment testing guide for TCP services

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zeabur",
   "description": "Zeabur CLI skills for deployment, template management, and troubleshooting",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "author": {
     "name": "Can"
   },

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Claude Code plugin for Zeabur CLI operations, deployment, and troubleshooting.
 
-**Current version: 1.11.0**
+**Current version: 1.11.1**
 
 ## Installation
 
@@ -49,6 +49,11 @@ claude --plugin-dir /path/to/zeabur-claude-plugin
 | `zeabur-email` | Manage Zeabur Email (ZSend) service | Email domains, API keys, webhooks, ZSend |
 
 ## Changelog
+
+### 1.11.1
+
+- Added post-deployment testing guide for TCP services in `zeabur-template` skill
+- Clarified `PORT_FORWARDED_HOSTNAME` and `PORT_FORWARDED_PORT` variable descriptions
 
 ### 1.11.0
 

--- a/skills/zeabur-template/SKILL.md
+++ b/skills/zeabur-template/SKILL.md
@@ -242,8 +242,8 @@ localization:
 | `${ZEABUR_WEB_DOMAIN}` | Domain only (e.g. `app.zeabur.app`) |
 | `${CONTAINER_HOSTNAME}` | Internal hostname for inter-service communication |
 | `${[PORTID]_PORT}` | Port value by port ID (e.g. `${DATABASE_PORT}`) |
-| `${PORT_FORWARDED_HOSTNAME}` | External hostname (for `instructions`) |
-| `${[PORTID]_PORT_FORWARDED_PORT}` | External forwarded port (for `instructions`) |
+| `${PORT_FORWARDED_HOSTNAME}` | External hostname for port forwarding (auto-set when enabled, usable in env vars and `instructions`) |
+| `${[PORTID]_PORT_FORWARDED_PORT}` | External forwarded port number (auto-set when enabled, usable in env vars and `instructions`) |
 
 The `ZEABUR_<PORT_ID>_URL` pattern: for a port named `web`, it becomes `${ZEABUR_WEB_URL}`; for `console`, it becomes `${ZEABUR_CONSOLE_URL}`.
 
@@ -332,6 +332,30 @@ spec:
 **Port Forwarding variables** (for use in `instructions` or readme):
 - `${PORT_FORWARDED_HOSTNAME}` — the external hostname
 - `${PROXY_PORT_FORWARDED_PORT}` — the external port (pattern: `${[PORTID]_PORT_FORWARDED_PORT}`)
+
+**Post-deployment testing for TCP services:**
+
+After deploying a TCP service, verify port forwarding is working:
+
+1. Check internal connectivity first (from inside the container):
+   ```bash
+   npx zeabur@latest service exec --id SERVICE_ID -- curl -x http://127.0.0.1:8888 https://ifconfig.co
+   ```
+
+2. Get the forwarded host:port from the Dashboard's **Networking** tab, or use:
+   ```bash
+   npx zeabur@latest service network --id SERVICE_ID
+   ```
+
+3. Test external connectivity:
+   ```bash
+   curl -x http://FORWARDED_HOST:FORWARDED_PORT https://ifconfig.co
+   ```
+
+If port forwarding shows as DISABLED, enable it:
+```bash
+npx zeabur@latest service port-forward --id SERVICE_ID --enable
+```
 
 ## Quick Reference: Headless Services (no HTTP)
 


### PR DESCRIPTION
## Summary

- Added a "Post-deployment testing for TCP services" subsection to the TCP Services quick reference, covering internal connectivity checks, retrieving forwarded host:port, external testing, and enabling port forwarding if disabled.
- Clarified `PORT_FORWARDED_HOSTNAME` and `PORT_FORWARDED_PORT` built-in variable descriptions to indicate they are auto-set when port forwarding is enabled and usable in both env vars and `instructions`.
- Bumped version to 1.11.1 and updated changelog.

## Test plan

- [ ] Verify the new testing steps in SKILL.md render correctly in markdown
- [ ] Confirm CLI commands (`service network`, `service port-forward`, `service exec`) match current Zeabur CLI interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped plugin version to 1.11.1

* **Documentation**
  * Clarified port forwarding variable descriptions for better clarity
  * Added post-deployment testing guidance for TCP services, including connectivity verification steps and command examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->