### PR TITLE
docs(zeabur-port-mismatch): add CLI diagnostic commands

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zeabur",
   "description": "Zeabur CLI skills for deployment, template management, and troubleshooting",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "author": {
     "name": "Can"
   },

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Claude Code plugin for Zeabur CLI operations, deployment, and troubleshooting.
 
-**Current version: 1.11.1**
+**Current version: 1.11.2**
 
 ## Installation
 
@@ -49,6 +49,10 @@ claude --plugin-dir /path/to/zeabur-claude-plugin
 | `zeabur-email` | Manage Zeabur Email (ZSend) service | Email domains, API keys, webhooks, ZSend |
 
 ## Changelog
+
+### 1.11.2
+
+- Updated `zeabur-port-mismatch` skill with CLI diagnostic commands (`service network`, `service port-forward`)
 
 ### 1.11.1
 

--- a/skills/zeabur-port-mismatch/SKILL.md
+++ b/skills/zeabur-port-mismatch/SKILL.md
@@ -20,8 +20,16 @@ Proxy expects service on port X, but service listens on port Y.
 
 ## Diagnose
 
-1. Check what port proxy expects (from Caddyfile/nginx.conf)
-2. Check what port container exposes (Dockerfile `EXPOSE`)
+1. Check port forwarding status and actual forwarded ports:
+   ```bash
+   npx zeabur@latest service network --id SERVICE_ID
+   ```
+2. Check what port the container is actually listening on:
+   ```bash
+   npx zeabur@latest service exec --id SERVICE_ID -- netstat -tlnp
+   ```
+3. Check what port proxy expects (from Caddyfile/nginx.conf)
+4. Check what port container exposes (Dockerfile `EXPOSE`)
 
 ## Common Mismatches
 
@@ -73,7 +81,25 @@ HTTPServer(('0.0.0.0', 8080), H).serve_forever()
 exec my-headless-app
 ```
 
+## Port Forwarding Not Working
+
+If a TCP service is deployed but not reachable externally:
+
+1. Check if port forwarding is enabled:
+   ```bash
+   npx zeabur@latest service port-forward --id SERVICE_ID
+   ```
+2. Enable it if disabled:
+   ```bash
+   npx zeabur@latest service port-forward --id SERVICE_ID --enable
+   ```
+3. Verify the forwarded endpoint:
+   ```bash
+   npx zeabur@latest service network --id SERVICE_ID
+   # Output: proxy (TCP 8888) → 34.x.x.x:20143
+   ```
+
 ## See Also
 
-- `zeabur-template` — template YAML reference for port configuration
+- `zeabur-template` — template YAML reference for port configuration (including TCP services and `portForwarding`)
 - `zeabur-deployment-logs` — check logs to confirm port binding


### PR DESCRIPTION
## Summary

- Add `service network` and `service exec -- netstat` to **Diagnose** section for checking actual port state
- Add **"Port Forwarding Not Working"** section with `service port-forward` commands to check/enable port forwarding
- These commands are available in CLI v0.10.0+

## Context

CLI v0.10.0 added `service port-forward` and enhanced `service network` to show forwarded host:port. The port-mismatch skill should reference these as diagnostic tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 1.11.2

* **Documentation**
  * Enhanced port-forwarding troubleshooting guide with expanded diagnostic steps
  * Added comprehensive workflow for enabling and verifying port-forwarding
  * Updated related resources and references for better guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->