### PR TITLE
docs(server-list): add non-interactive SSH usage

### DIFF
--- a/skills/zeabur-server-list/SKILL.md
+++ b/skills/zeabur-server-list/SKILL.md
@@ -47,6 +47,30 @@ npx zeabur@latest server ssh <server-id>
 
 For managed servers, the password is fetched automatically. If `sshpass` is installed, login is fully automatic; otherwise the password is printed for manual entry.
 
+### Non-Interactive SSH (Running Remote Commands)
+
+In non-interactive environments (e.g. Claude Code, CI/CD), you cannot use an interactive SSH session. Instead, **pipe commands via stdin** with `-i=false`:
+
+```bash
+echo 'kubectl get pods -A' | npx zeabur@latest server ssh <server-id> -i=false
+```
+
+For multiple commands, separate them with `;` or `&&`:
+
+```bash
+echo 'kubectl get pods -A; kubectl get svc -A' | npx zeabur@latest server ssh <server-id> -i=false
+```
+
+**Important notes:**
+
+- The output includes the server's MOTD (Message of the Day) banner. Filter it out when parsing results:
+  ```bash
+  echo 'kubectl get pods -A' | npx zeabur@latest server ssh <server-id> -i=false 2>&1 \
+    | grep -v "Welcome\|Documentation\|Management\|Support\|System load\|Usage of /\|Memory usage\|Swap usage\|Strictly\|just raised\|https://ubuntu\|Expanded\|updates can\|To see these\|Enable ESM\|See https://ubuntu\|New release\|Run 'do-release\|restart required\|INFO.*Connecting\|Pseudo-terminal\|^ \*"
+  ```
+- If the remote command has a non-zero exit code (e.g. `grep` with no matches), the CLI will print `ERROR exit status 1`. This does not necessarily mean the SSH connection failed.
+- Heredoc syntax (`<<'EOF'`) does **not** work reliably with this command. Always use `echo '...' |` instead.
+
 ## See Also
 
 - `zeabur-server-catalog` — browse available servers to rent


### PR DESCRIPTION
## Summary
- Add documentation for running remote commands on dedicated servers in non-interactive environments (Claude Code, CI/CD)
- Document the `echo '...' | npx zeabur@latest server ssh <id> -i=false` pattern
- Include tips for filtering MOTD noise and common gotchas (exit codes, heredoc incompatibility)

## Context
During a debugging session, we discovered that the skill only documented interactive SSH usage. In Claude Code, interactive SSH sessions don't work — commands must be piped via stdin. This was a knowledge gap that caused unnecessary trial-and-error.

## Test plan
- [ ] Verify `echo 'hostname' | npx zeabur@latest server ssh <server-id> -i=false` works as documented
- [ ] Verify MOTD filter grep pattern correctly strips banner output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on executing remote SSH commands in non-interactive environments, including example implementations and operational notes regarding server output handling and error code interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->