### PR TITLE
docs: add ICANN registrant verification to domain registrant skill

### DIFF
--- a/skills/zeabur-domain-registrant/SKILL.md
+++ b/skills/zeabur-domain-registrant/SKILL.md
@@ -91,7 +91,9 @@ npx zeabur@latest domain verification resend --id <registered-domain-id> -i=fals
 
 ### Update Registrant Contact
 
-If the registrant email was entered incorrectly and cannot receive verification emails, update the contact info:
+If the registrant email was entered incorrectly and cannot receive verification emails, update the contact info.
+
+> **Prerequisite:** This operation requires the domain owner's account permissions.
 
 ```bash
 npx zeabur@latest domain verification update-contact \


### PR DESCRIPTION
## Summary

Update the `zeabur-domain-registrant` skill to document the new ICANN registrant verification features added in zeabur/backend#1766 and zeabur/cli#191.

### Added Documentation
- **Resend verification email** — `npx zeabur@latest domain verification resend`
- **Update registrant contact** — GraphQL mutation for fixing wrong emails (admin only)
- **Check verification status** — GraphQL query for `registrantVerificationStatus`
- Updated skill description to include verification-related triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Expanded registrant docs to include ICANN registrant verification alongside registrant profile management.
* Added section describing verification status checks (with interactive mode) and defined status values.
* Documented CLI flow to resend verification emails with interactive domain selection.
* Added instructions for updating registrant contact details; changing email restarts verification.
* Noted possible 60-day transfer lock when registrant email is changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->