### PR TITLE
docs: add API endpoint info to AI Hub skill

### DIFF
--- a/skills/zeabur-ai-hub/SKILL.md
+++ b/skills/zeabur-ai-hub/SKILL.md
@@ -24,7 +24,7 @@ AI Hub is OpenAI-compatible. Users can pick the region closest to them:
 import OpenAI from "openai";
 
 const client = new OpenAI({
-    baseURL: "https://hnd1.aihub.zeabur.ai/",  // or sfo1
+    baseURL: "https://hnd1.aihub.zeabur.ai/v1",  // or sfo1
     apiKey: "sk-xxxxxxxxxxxxxxxx",              // from AI Hub dashboard
 });
 
@@ -41,7 +41,7 @@ const stream = await client.chat.completions.create({
 from openai import OpenAI
 
 client = OpenAI(
-    base_url="https://hnd1.aihub.zeabur.ai/",  # or sfo1
+    base_url="https://hnd1.aihub.zeabur.ai/v1",  # or sfo1
     api_key="sk-xxxxxxxxxxxxxxxx",              # from AI Hub dashboard
 )
 
@@ -65,7 +65,6 @@ curl https://hnd1.aihub.zeabur.ai/v1/chat/completions \
 
 - **Anthropic SDK**: set `baseURL` / `base_url` to the endpoint above
 - **Vercel AI SDK (`@ai-sdk/openai`)**: set `baseURL` to the endpoint above
-- **Google Generative AI SDK**: set `baseUrl` to `https://<region>.aihub.zeabur.ai/gemini`
 
 ### Environment Variables
 


### PR DESCRIPTION
## Summary
- Added AI Hub regional endpoint URLs (HND1 Tokyo, SFO1 San Francisco)
- Added quick start examples for OpenAI SDK (JS/Python/curl)
- Added SDK compatibility notes (Anthropic, Vercel AI, Google Generative AI)
- Added recommended environment variables for Zeabur deployments
- Updated skill description to trigger on endpoint-related queries

## Test plan
- [ ] Verify skill triggers when asking about AI Hub endpoints or base URL
- [ ] Confirm endpoint URLs match production (`hnd1.aihub.zeabur.ai`, `sfo1.aihub.zeabur.ai`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added API Endpoints section with region-specific base URLs (Tokyo HND1, San Francisco SFO1).
  * Added Quick Start examples for JavaScript/TypeScript, Python, and curl showing baseURL/base_url usage.
  * Added SDK compatibility guidance for OpenAI-compatible integrations, Anthropic, Vercel AI, and Google Generative AI SDKs.
  * Documented environment variable recommendations (OPENAI_API_KEY, OPENAI_BASE_URL).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->