### PR TITLE
docs: fix heading format in hard-won-lessons, improve cross-references

### DIFF
--- a/skills/zeabur-ai-hub/SKILL.md
+++ b/skills/zeabur-ai-hub/SKILL.md
@@ -140,3 +140,4 @@ Both `--threshold` and `--amount` are in whole dollars.
 ## See Also
 
 - `zeabur-service-list` — get service IDs for other operations
+- `zeabur-variables` — set API keys as environment variables on services

--- a/skills/zeabur-email/SKILL.md
+++ b/skills/zeabur-email/SKILL.md
@@ -97,4 +97,5 @@ npx zeabur@latest email webhooks delete --id <webhook-id> -i=false
 ## See Also
 
 - `zeabur-domain-url` — configure public domains and URLs for services
+- `zeabur-domain-dns` — manage DNS records needed for email domain verification
 - `zeabur-variables` — set environment variables (e.g., email API keys as env vars)

--- a/skills/zeabur-template-backup/SKILL.md
+++ b/skills/zeabur-template-backup/SKILL.md
@@ -125,3 +125,4 @@ git push
 ## See Also
 
 - `zeabur-template` — template YAML reference and editing guide
+- `zeabur-template-publish` — publish modified templates back to the marketplace

--- a/skills/zeabur-template/references/hard-won-lessons.md
+++ b/skills/zeabur-template/references/hard-won-lessons.md
@@ -1,6 +1,6 @@
 # Hard-Won Lessons (from real template challenges)
 
-##Wait for database readiness
+## Wait for database readiness
 Zeabur's `dependencies` field only ensures services are **deployed**, not that they're **ready to accept connections**. A database container can take 5-15 seconds to initialize.
 
 **Preferred approach: `healthCheck`** — add a health check to the dependency service so Zeabur waits until the port is ready before starting dependent services:
@@ -29,7 +29,7 @@ args:
 ```
 Note: `nc` (netcat) is available on most Alpine-based images. If not, use `wget --spider` or a node one-liner.
 
-##Pin image tags — never use `latest`
+## Pin image tags — never use `latest`
 Always pin Docker images to a specific version tag (e.g., `rajnandan1/kener:4.0.16`). Never use `:latest` in templates because:
 - Zeabur's registry may cache an old version of `latest`, causing users to deploy stale or broken images
 - Upstream breaking changes silently affect all new deployments
@@ -37,14 +37,14 @@ Always pin Docker images to a specific version tag (e.g., `rajnandan1/kener:4.0.
 
 When the upstream releases a new version, update the template with the new pinned tag and test before publishing.
 
-##Study the project's own Dockerfile and docker-compose
+## Study the project's own Dockerfile and docker-compose
 **Never guess startup commands.** Instead:
 1. Read the project's `Dockerfile` to understand the build stages and the final `CMD`/`ENTRYPOINT`
 2. Read `docker-compose.yml` and especially `docker-compose.fullapp.yml` (or `docker-compose.prod.yml`) for the production startup command -- these often override the Dockerfile's CMD with init/migrate logic
 3. Check the app's `package.json` scripts to understand what `yarn start` or `npm start` actually runs
 4. The startup command in docker-compose is battle-tested -- copy it, don't reinvent it
 
-##Memory-heavy apps need lighter startup
+## Memory-heavy apps need lighter startup
 Apps that spawn workers, schedulers, and the web server all in one process may OOM on Zeabur's default allocation. Signs of OOM:
 - Container starts, runs for 1-2 minutes, then crashes with no error logs (just `BackOff: Back-off restarting failed container`)
 - No application-level crash message -- the kernel kills the process silently
@@ -54,7 +54,7 @@ Solutions:
 - Disable non-essential background processes via env vars (e.g., `AUTO_SPAWN_WORKERS=false`)
 - If workers are needed, consider splitting them into a separate service
 
-##First-run init with persistent marker
+## First-run init with persistent marker
 For apps that need first-time initialization (DB schema, seed data, admin users), use a marker file in a persistent volume:
 ```yaml
 args:
@@ -75,7 +75,7 @@ Key points:
 - Use `exec` for the final server process so it becomes PID 1 and receives signals properly
 - Read init logs carefully for the **actual default credentials** -- don't assume from docs
 
-##Working directory matters
+## Working directory matters
 When overriding `command`/`args`, be aware of the Dockerfile's `WORKDIR`. In monorepo apps, different commands need to run from different directories:
 ```yaml
 args:
@@ -87,16 +87,16 @@ args:
         exec next start -p 3000
 ```
 
-##ImagePullBackOff recovery
+## ImagePullBackOff recovery
 When a pod is stuck in `ImagePullBackOff` (e.g., after making a Docker Hub repo public), the Kubernetes backoff timer prevents immediate retries. Fix by restarting the service:
 ```bash
 npx zeabur@latest service restart --id SERVICE_ID -i=false -y
 ```
 
-##Disable unused monitoring agents
+## Disable unused monitoring agents
 Many production images ship with New Relic, Datadog, or similar APM agents. These require license keys and consume memory. Add `NEW_RELIC_ENABLED=false` or equivalent env vars to disable them cleanly. Check if the `start` script injects agents via `NODE_OPTIONS='-r newrelic'` -- these still run even if the agent errors out.
 
-##Verify all URLs before publishing
+## Verify all URLs before publishing
 Before publishing a template, verify that ALL URLs return HTTP 200:
 - `icon` URL
 - `coverImage` URL


### PR DESCRIPTION
## Summary

- **Fix 9 malformed headings** in `hard-won-lessons.md` — all `##` headings were missing the required space after `##` (e.g., `##Wait for` → `## Wait for`), violating CommonMark spec and causing rendering issues in some markdown parsers
- **Improve cross-references** in 3 skills:
  - `zeabur-ai-hub` → added `zeabur-variables` (users need to set API keys as env vars)
  - `zeabur-template-backup` → added `zeabur-template-publish` (download → modify → re-publish workflow)
  - `zeabur-email` → added `zeabur-domain-dns` (email domains require DNS record setup)

### Files changed
- `skills/zeabur-template/references/hard-won-lessons.md` — fixed 9 headings
- `skills/zeabur-ai-hub/SKILL.md` — added See Also entry
- `skills/zeabur-template-backup/SKILL.md` — added See Also entry
- `skills/zeabur-email/SKILL.md` — added See Also entry

## Test plan
- [ ] Verify all headings render correctly as H2 in GitHub markdown preview
- [ ] Confirm cross-referenced skill names match actual skill directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)