### PR TITLE
fix: minor consistency improvements (server-list, domain-url, domain-dns)

### DIFF
--- a/skills/zeabur-domain-dns/SKILL.md
+++ b/skills/zeabur-domain-dns/SKILL.md
@@ -10,7 +10,7 @@ description: Use when managing DNS records for Zeabur-registered domains. Use wh
 ## List DNS Records
 
 ```bash
-npx zeabur@latest domain dns list --domain example.com -i=false
+npx zeabur@latest domain dns list --domain example.com -i=false --json
 ```
 
 ## Create a DNS Record

--- a/skills/zeabur-domain-url/SKILL.md
+++ b/skills/zeabur-domain-url/SKILL.md
@@ -109,5 +109,6 @@ npx zeabur@latest domain delete --id <service-id> --domain <domain> -y -i=false
 ## See Also
 
 - `zeabur-template` — template YAML reference for domain binding and env vars
+- `zeabur-domain-register` — search, purchase, and manage registered domains
 - `zeabur-domain-dns` — manage DNS records for Zeabur-registered domains
 - `zeabur-server-list` — find server IPs for A record configuration

--- a/skills/zeabur-server-list/SKILL.md
+++ b/skills/zeabur-server-list/SKILL.md
@@ -34,7 +34,7 @@ Shows detailed info: CPU/memory/disk usage, provider, location, managed status, 
 ## Reboot a Server
 
 ```bash
-npx zeabur@latest server reboot <server-id> -y
+npx zeabur@latest server reboot <server-id> -y -i=false
 ```
 
 **`-y` skips confirmation prompt** — required for non-interactive use.


### PR DESCRIPTION
## Summary

Three small consistency fixes:

- **`zeabur-server-list`**: Add missing `-i=false` to `server reboot` command (all other commands in all skills include this flag)
- **`zeabur-domain-url`**: Add `zeabur-domain-register` to See Also — domains must be registered before DNS/URL can be configured
- **`zeabur-domain-dns`**: Add `--json` flag to `dns list` command for consistency with other list commands

### Files changed
- `skills/zeabur-server-list/SKILL.md`
- `skills/zeabur-domain-url/SKILL.md`
- `skills/zeabur-domain-dns/SKILL.md`

## Test plan
- [ ] Verify `server reboot` works with `-i=false`
- [ ] Verify `domain dns list` supports `--json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)