### PR TITLE
fix: update server catalog JSON example to match actual CLI output

### DIFF
--- a/skills/zeabur-server-catalog/SKILL.md
+++ b/skills/zeabur-server-catalog/SKILL.md
@@ -19,21 +19,24 @@ Returns JSON with all providers, regions, and plans:
 {
   "providers": [
     {
-      "code": "hetzner",
+      "code": "HETZNER",
       "name": "Hetzner",
       "regions": [
         {
-          "id": "fsn1",
-          "name": "Falkenstein",
-          "city": "Falkenstein",
+          "id": "nbg1",
+          "name": "Nuremberg",
+          "city": "",
           "country": "DE",
+          "continent": "",
           "plans": [
             {
-              "name": "CAX11",
+              "name": "cpx22",
               "cpu": 2,
-              "memory": 4096,
-              "disk": 40,
-              "price": 399,
+              "memory": 4,
+              "disk": 80,
+              "egress": 20000,
+              "price": 6,
+              "originalPrice": 7.46,
               "available": true
             }
           ]
@@ -44,7 +47,11 @@ Returns JSON with all providers, regions, and plans:
 }
 ```
 
-**Note:** `price` is in cents (USD). Divide by 100 for dollars per month.
+**Notes:**
+- `price` is in **USD per month** (integer or float). `originalPrice` shows the provider's list price before Zeabur discount.
+- `memory` is in **GB** (not MB).
+- `egress` is monthly bandwidth in **GB**.
+- `code` is **uppercase** (e.g. `HETZNER`, `VULTR`), but `--provider` filter accepts lowercase.
 
 ## Filter Options
 
@@ -53,7 +60,7 @@ Returns JSON with all providers, regions, and plans:
 | `--provider` | `--provider hetzner` | Filter by provider code |
 | `--country` | `--country DE` | Filter by country code |
 | `--min-cpu` | `--min-cpu 4` | Minimum CPU cores |
-| `--min-memory` | `--min-memory 8192` | Minimum memory in MB |
+| `--min-memory` | `--min-memory 8192` | Minimum memory in **MB** (note: JSON output uses GB) |
 | `--gpu` | `--gpu` | Only GPU plans |
 
 ```bash


### PR DESCRIPTION
## Summary

The `zeabur-server-catalog` skill's JSON example had several inaccuracies compared to actual CLI 0.13.1 output.

## Changes

| Field | Before (docs) | After (actual CLI) |
|-------|--------------|-------------------|
| `price` | `399` (documented as cents) | `6` (actually USD/month) |
| `memory` | `4096` (documented as MB) | `4` (actually GB) |
| `code` | `"hetzner"` (lowercase) | `"HETZNER"` (uppercase) |
| `egress` | missing | `20000` (GB) |
| `originalPrice` | missing | `7.46` (provider list price) |
| `continent` | missing | `""` |

Also clarified that `--min-memory` filter uses MB while the JSON output uses GB.

## Verification

```bash
npx zeabur@latest server catalog --provider hetzner --country DE -i=false --json
```

## Test plan

- [ ] Verify JSON example matches CLI output format
- [ ] Verify price/memory unit notes are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated server catalog schema with revised pricing format (now USD per month) and memory units (now in GB).
  * Provider codes now consistently displayed in uppercase format.
  * Added egress field documentation for server plan specifications.
  * Clarified memory flag handling and case-sensitivity requirements.
  * Improved documentation notes on pricing units and discount behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->