### PR TITLE
fix: correct domain validation error codes in domain-url skill

### DIFF
--- a/skills/zeabur-domain-url/SKILL.md
+++ b/skills/zeabur-domain-url/SKILL.md
@@ -67,8 +67,7 @@ npx zeabur@latest domain create --id <service-id> -g --domain myapp -y -i=false
 Validation rules for generated domain prefix:
 - At least 3 characters
 - No dots allowed — only alphanumeric and hyphens
-- Error `DOMAIN_NAME_TOO_SHORT` if less than 3 chars
-- Error `UNSUPPORTED_DOMAIN_NAME` if prefix contains dots
+- Invalid prefixes (too short, contains dots, etc.) return `DOMAIN_UNAVAILABLE` or `INVALID_DOMAIN_NAME`
 
 ### Create a custom domain
 


### PR DESCRIPTION
## Summary

The documented error codes for invalid generated domain prefixes don't match actual CLI behavior (tested with CLI 0.13.1).

| Scenario | Documented error code | Actual error code |
|----------|----------------------|-------------------|
| Prefix < 3 chars (e.g. "ab") | `DOMAIN_NAME_TOO_SHORT` | `DOMAIN_UNAVAILABLE` |
| Prefix contains dots (e.g. "test.dot") | `UNSUPPORTED_DOMAIN_NAME` | `DOMAIN_UNAVAILABLE` |
| No `--domain` flag | `INVALID_DOMAIN_NAME` | `INVALID_DOMAIN_NAME` ✅ |

Replaced the specific (incorrect) error code names with a generic description of actual behavior.

## Test plan

- [ ] Verify short prefix returns `DOMAIN_UNAVAILABLE`
- [ ] Verify prefix with dots returns `DOMAIN_UNAVAILABLE`
- [ ] Verify missing `--domain` flag returns `INVALID_DOMAIN_NAME`

🤖 Generated with [Claude Code](https://claude.com/claude-code)