### PR TITLE
feat: add image tag upgrade to zeabur-update-service

### DIFF
--- a/skills/zeabur-update-service/SKILL.md
+++ b/skills/zeabur-update-service/SKILL.md
@@ -35,7 +35,9 @@ npx zeabur@latest service restart --id <service-id> -y -i=false
 
 ## Update Image Tag (Upgrade Service Version)
 
-For prebuilt/marketplace services, update the image tag to upgrade:
+For prebuilt/marketplace services, update the image tag to upgrade to a newer version.
+
+### Workflow
 
 ```bash
 # 1. Get service ID
@@ -45,7 +47,16 @@ npx zeabur@latest service list --project-id <project-id> -i=false
 npx zeabur@latest service update tag --id <service-id> -t <new-tag> -y -i=false
 ```
 
-> **Note:** This triggers a new deployment with the updated image. The service will restart.
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--id` | Service ID (**required**, do not use `--name`) |
+| `-t, --tag` | New image tag to deploy |
+| `--env-id` | Environment ID (optional, resolved automatically) |
+| `-y, --yes` | Skip confirmation |
+
+> **Note:** Updating the tag triggers a new deployment. The service will restart with the updated image.
 
 ## When to Use
 


### PR DESCRIPTION
## Summary

- Adds "Update Image Tag" section to `zeabur-update-service` skill for upgrading prebuilt/marketplace service versions
- Adds trigger keywords: "upgrade service version", "update image tag", "change service tag"
- Adds "Upgrade a prebuilt service to a newer version" to the "When to Use" list

## Why this change?

"How do I upgrade an already-deployed service?" is a common question. The `service update tag` command exists in the CLI but no skill mentions it. Adding it to `zeabur-update-service` is the most natural fit since the skill name is literally "update service".

## Test plan

- [x] Verified `service update tag --id <id> -t <tag> -y -i=false` syntax against CLI help
- [x] Confirmed the new section follows existing skill formatting conventions
- [x] Existing env var workflow and caveats unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded docs with a new workflow for upgrading prebuilt/marketplace services by changing their image tag. Adds clear use cases (e.g., upgrade service version) and step-by-step CLI instructions to list services and update image tags. Notes that changing the tag triggers a redeploy/restart of the service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->