### PR TITLE
feat: add zeabur-service-metric skill for performance diagnostics

### DIFF
--- a/skills/zeabur-service-metric/SKILL.md
+++ b/skills/zeabur-service-metric/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: zeabur-service-metric
+description: Use when diagnosing service performance issues. Use when user says "service is slow", "high CPU", "out of memory", "check resource usage", "monitor service", or "why is my service lagging".
+---
+
+# Zeabur Service Metrics
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Check Metrics
+
+```bash
+# CPU usage
+npx zeabur@latest service metric CPU --id <service-id> -i=false
+
+# Memory usage
+npx zeabur@latest service metric MEMORY --id <service-id> -i=false
+
+# Network I/O
+npx zeabur@latest service metric NETWORK --id <service-id> -i=false
+```
+
+Use `--hour <N>` to change the time window (default: 2 hours):
+
+```bash
+npx zeabur@latest service metric CPU --id <service-id> --hour 24 -i=false
+```
+
+## Diagnostic Workflow
+
+When a user reports a slow or unresponsive service, **check metrics before restarting**:
+
+```bash
+# 1. Get service ID
+npx zeabur@latest service list --project-id <project-id> -i=false
+
+# 2. Check CPU — is the service compute-bound?
+npx zeabur@latest service metric CPU --id <service-id> -i=false
+
+# 3. Check memory — is the service running out of RAM?
+npx zeabur@latest service metric MEMORY --id <service-id> -i=false
+
+# 4. Check network — is there unusual traffic?
+npx zeabur@latest service metric NETWORK --id <service-id> -i=false
+
+# 5. Check logs for errors
+npx zeabur@latest deployment log --id <service-id> -i=false
+```
+
+**Then decide the action based on evidence:**
+
+| Symptom | Likely cause | Action |
+|---------|-------------|--------|
+| CPU consistently near 100% | Compute-bound workload | Upgrade plan or optimize code |
+| Memory climbing until OOM | Memory leak or undersized plan | Restart (temporary) + fix leak |
+| Network spikes | Traffic surge or external API issues | Check logs for request patterns |
+| All metrics normal | Application-level bug | Check deployment logs |
+
+## See Also
+
+- `zeabur-deployment-logs` — check logs after identifying the bottleneck
+- `zeabur-restart` — restart only after diagnosing the issue
+- `zeabur-service-list` — get service IDs needed for metric queries


### PR DESCRIPTION
## Summary

- Adds new `zeabur-service-metric` skill covering `service metric CPU/MEMORY/NETWORK`
- Includes a **diagnostic workflow** that teaches the AI to check metrics before restarting
- Decision table maps symptoms (high CPU, memory climb, network spikes) to likely causes and actions

## Why this skill?

When users report "my service is slow", the AI currently has no way to check resource usage — it just suggests restarting. This skill gives the AI a proper diagnostic path: check metrics → identify bottleneck → take appropriate action.

## Test plan

- [x] Verified `service metric CPU/MEMORY/NETWORK --id <id> -i=false` returns data on a live service
- [x] Verified `--hour` flag for custom time windows
- [x] Followed existing skill conventions (see `zeabur-restart` for reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)