### PR TITLE
feat: add zeabur-port-forward skill for secure local access

### DIFF
--- a/skills/zeabur-port-forward/SKILL.md
+++ b/skills/zeabur-port-forward/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: zeabur-port-forward
+description: Use when user needs local access to a remote service (database, cache, internal API). Use when user says "connect to database locally", "port forward", "access service from my machine", "local database connection", or "expose port locally".
+---
+
+# Zeabur Port Forwarding
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Enable Port Forwarding
+
+```bash
+npx zeabur@latest service port-forward --id <service-id> --enable -i=false
+```
+
+## Disable Port Forwarding
+
+```bash
+npx zeabur@latest service port-forward --id <service-id> --disable -i=false
+```
+
+## Workflow
+
+```bash
+# 1. Get service ID (e.g., for a PostgreSQL service)
+npx zeabur@latest service list --project-id <project-id> -i=false
+
+# 2. Enable port forwarding
+npx zeabur@latest service port-forward --id <service-id> --enable -i=false
+
+# 3. Check network info for the forwarded hostname and port
+npx zeabur@latest service network --id <service-id> -i=false
+
+# 4. Connect locally using the provided hostname:port
+# e.g., psql -h <hostname> -p <port> -U <user> <database>
+
+# 5. Disable when done
+npx zeabur@latest service port-forward --id <service-id> --disable -i=false
+```
+
+## When to Use
+
+- Connect to a remote database (PostgreSQL, MySQL, Redis, MongoDB) from local machine
+- Debug an internal service that has no public domain
+- Run database migrations from a local script
+
+> **Security:** Use port forwarding instead of adding a public domain to databases or internal services. Public domains expose services to the internet — port forwarding provides access without that risk.
+
+## See Also
+
+- `zeabur-service-list` — get service IDs needed for port forwarding
+- `zeabur-domain-url` — for services that should be publicly accessible (not databases)
+- `zeabur-port-mismatch` — troubleshoot port configuration issues


### PR DESCRIPTION
## Summary

- Adds new `zeabur-port-forward` skill covering `service port-forward --enable/--disable`
- Workflow for connecting to remote databases (PostgreSQL, MySQL, Redis, MongoDB) from local machine
- **Security guardrail:** explicitly guides AI to prefer port forwarding over public domains for databases and internal services

## Why this skill?

When users ask "how do I connect to my database locally?", the AI may suggest adding a public domain to the database service — exposing it to the internet. Port forwarding is the correct and secure approach, but no skill mentions it. This skill prevents the AI from making a dangerous recommendation.

## Test plan

- [x] Verified `service port-forward --enable/--disable --id <id> -i=false` works on a live service
- [x] Verified `service network --id <id>` returns forwarded hostname and port after enabling
- [x] Followed existing skill conventions (see `zeabur-restart` for reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Zeabur port forwarding skill documentation with CLI usage instructions, example commands, and comprehensive step-by-step workflows for enabling/disabling service port forwarding and managing network connectivity.

* **Documentation**
  * Includes typical use cases, security guidance notes, and cross-references to complementary skills for service discovery and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->