### PR TITLE
feat: add zeabur-service-suspend skill for cost management

### DIFF
--- a/skills/zeabur-service-suspend/SKILL.md
+++ b/skills/zeabur-service-suspend/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: zeabur-service-suspend
+description: Use when pausing a service to save costs without deleting it. Use when user says "suspend service", "pause service", "stop billing", "save costs", "temporarily stop service", or "resume service".
+---
+
+# Zeabur Service Suspend & Resume
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Suspend a Service
+
+```bash
+npx zeabur@latest service suspend --id <service-id> -y -i=false
+```
+
+The service stops running and stops incurring compute charges. Data volumes are preserved.
+
+## Resume a Service
+
+Restarting a suspended service resumes it:
+
+```bash
+npx zeabur@latest service restart --id <service-id> -y -i=false
+```
+
+## Workflow
+
+```bash
+# 1. Get service ID
+npx zeabur@latest service list --project-id <project-id> -i=false
+
+# 2. Suspend (stops billing)
+npx zeabur@latest service suspend --id <service-id> -y -i=false
+
+# 3. Later — resume when needed
+npx zeabur@latest service restart --id <service-id> -y -i=false
+```
+
+## Suspend vs Delete
+
+| Action | Billing | Data | Can recover? |
+|--------|---------|------|-------------|
+| **Suspend** | Stops compute charges | Volumes preserved | Yes — restart to resume |
+| **Delete** | Stops all charges | Everything removed | No |
+
+> **Tip:** Suspend staging/dev services when not in use. Delete only when you no longer need the service at all.
+
+## See Also
+
+- `zeabur-restart` — resume a suspended service
+- `zeabur-service-delete` — permanently remove a service
+- `zeabur-service-list` — get service IDs


### PR DESCRIPTION
## Summary

- Adds new `zeabur-service-suspend` skill covering `service suspend` and resume (via `service restart`)
- **Suspend vs Delete comparison table** prevents AI from deleting services when the user just wants to pause billing
- Guides AI to recommend suspending staging/dev services when not in use

## Why this skill?

When users want to "stop" a service, the AI may suggest deleting it — losing all configuration and data. Suspend is the correct action for temporary stops: it preserves volumes and config while stopping compute charges. No existing skill mentions this option.

## Test plan

- [x] Verified `service suspend --id <id> -y -i=false` successfully suspends a running service
- [x] Verified `service restart --id <id> -y -i=false` resumes a suspended service
- [x] Followed existing skill conventions (see `zeabur-restart` for reference)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for the service suspension feature, including step-by-step instructions for pausing and resuming Zeabur services. The documentation provides exact command syntax, practical workflow examples, and a detailed comparison between suspending and permanently deleting services to help users understand data preservation implications and make informed service management decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->