### PR TITLE
docs: warn about variable reference CLI bug and template DNS limitation

### DIFF
--- a/skills/zeabur-template-deploy/skill.md
+++ b/skills/zeabur-template-deploy/skill.md
@@ -124,6 +124,46 @@ spec:
       description: Database name
 ```
 
+## Known Limitations
+
+### Custom PREBUILT template YAML: internal DNS may not register
+
+Services deployed via custom template YAML files (`-f template.yaml`) with `template: PREBUILT` may not get registered in Zeabur's internal DNS (`*.zeabur.internal`). This means other services in the same project cannot connect to them by hostname. See [zeabur/cli#204](https://github.com/zeabur/cli/issues/204).
+
+**Workaround**: For database services (PostgreSQL, MySQL, Redis), use the marketplace template code (`-c <CODE>`) instead of custom YAML files. Marketplace templates are properly registered in internal DNS.
+
+```bash
+# RECOMMENDED — deploy via marketplace code (has internal DNS)
+npx zeabur@latest template search postgresql -i=false --json
+npx zeabur@latest template deploy -i=false -c <CODE> --project-id <id>
+
+# NOT RECOMMENDED — custom YAML may lack internal DNS
+npx zeabur@latest template deploy -i=false -f my-pg.yaml --project-id <id>
+```
+
+### Custom template YAML schema: `spec` nesting
+
+Template YAML requires `spec.services[].spec.source`, not `spec.services[].source`:
+
+```yaml
+# CORRECT
+spec:
+  services:
+    - name: my-service
+      template: PREBUILT
+      spec:                    # <-- required nesting
+        source:
+          image: postgres:17
+
+# WRONG — will fail with "missing property 'spec'"
+spec:
+  services:
+    - name: my-service
+      template: PREBUILT
+      source:                  # <-- missing spec wrapper
+        image: postgres:17
+```
+
 ## Common Issues
 
 | Issue | Solution |
@@ -132,6 +172,8 @@ spec:
 | Missing variables error | Add all required `--var` flags |
 | Variable with `${REF}` | Use literal value or set in Dashboard after deploy |
 | DOMAIN type validation | Domain availability checked automatically |
+| `missing property 'spec'` | Wrap `source`/`ports`/`env` under `spec:` (double-nested) |
+| Other services can't connect to DB | Use marketplace code (`-c`) not custom YAML (`-f`) for databases |
 
 ## See Also
 

--- a/skills/zeabur-variables/SKILL.md
+++ b/skills/zeabur-variables/SKILL.md
@@ -66,15 +66,20 @@ After running `env`, you must restart the service manually to apply changes.
 
 ## Variable References
 
+> **Warning:** The CLI `-k` flag uses Cobra's `StringToStringVar` parser which cannot reliably handle values containing `${}`, even with single quotes. The value may be truncated or emptied. See [zeabur/cli#201](https://github.com/zeabur/cli/issues/201).
+
 ```bash
 # WRONG — shell expands ${VAR} to empty
 npx zeabur@latest variable create --id <service-id> -k "REDIS_URL=${REDIS_URI_INTERNAL}" -y -i=false
 
-# CORRECT — single quotes prevent shell expansion
+# STILL UNRELIABLE — single quotes prevent shell expansion but Cobra's CSV parser may still mangle the value
 npx zeabur@latest variable create --id <service-id> -k 'REDIS_URL=${REDIS_URI_INTERNAL}' -y -i=false
 
-# Or set references in Zeabur Dashboard instead
+# RECOMMENDED — set variable references in Zeabur Dashboard
+# Or use GraphQL API with updateEnvironmentVariable(data: Map!) mutation
 ```
+
+For cross-service variable references like `${POSTGRESQL.POSTGRES_CONNECTION_STRING}`, **always use the Zeabur Dashboard** or the GraphQL API directly until the CLI bug is fixed.
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary

Adds documentation warnings for two issues discovered during real-world usage:

- **`zeabur-variables` skill**: The `-k` flag cannot reliably handle values containing `${}` (e.g., `${POSTGRESQL.POSTGRES_CONNECTION_STRING}`) due to Cobra's `StringToStringVar` parser limitation. Added warning and recommendation to use Dashboard or GraphQL API. Ref: zeabur/cli#201

- **`zeabur-template-deploy` skill**: Custom PREBUILT template YAML services may not get internal DNS registration (`*.zeabur.internal`), preventing other services from connecting. Added workaround recommending marketplace code (`-c`) for database services. Also documented the `spec` nesting requirement in template YAML. Ref: zeabur/cli#204

## Changes

- `skills/zeabur-variables/SKILL.md` — expanded Variable References section with warning and recommended approach
- `skills/zeabur-template-deploy/SKILL.md` — added Known Limitations section (DNS, YAML schema) and updated Common Issues table

Closes #39