### PR TITLE
fix: clarify server-project relationship to prevent SSH-based deployment

### DIFF
--- a/skills/zeabur-deploy/SKILL.md
+++ b/skills/zeabur-deploy/SKILL.md
@@ -20,6 +20,17 @@ npx zeabur@latest project list -i=false --json
 
 **Do not proceed with deployment until the target project is confirmed.**
 
+### Deploying to a Specific Dedicated Server
+
+If the user asks to deploy to a specific **server** (e.g. "deploy to my AWS Tokyo server"), do **NOT** SSH into the server. Zeabur dedicated servers are managed via the platform — you deploy services through the Zeabur CLI, not by manually placing files on the machine.
+
+To find the project bound to a server:
+
+1. Get the server ID from `npx zeabur@latest server list -i=false` (or from conversation context).
+2. In the `project list --json` output, look for a project whose `Region.ID` matches `server-<server-id>`.
+3. If a matching project exists, use its project ID to deploy.
+4. If no matching project exists, **invoke the `zeabur-project-create` skill** to create one on that server.
+
 ## Choosing a Deploy Method
 
 Zeabur supports two ways to deploy a project:

--- a/skills/zeabur-server-list/SKILL.md
+++ b/skills/zeabur-server-list/SKILL.md
@@ -39,7 +39,14 @@ npx zeabur@latest server reboot <server-id> -y
 
 **`-y` skips confirmation prompt** — required for non-interactive use.
 
-## SSH into a Server
+## Servers and Projects
+
+Each dedicated server can have Zeabur projects bound to it. A project's `Region.ID` will be `server-<server-id>` when it is deployed on a dedicated server.
+
+- **To deploy a service to a server**, use the `zeabur-deploy` skill with the project bound to that server — do NOT SSH in and manually set up web servers or copy files.
+- **SSH is for low-level debugging only** (e.g. checking kubectl, inspecting disk, network diagnostics). It is not needed for deploying or managing services.
+
+## SSH into a Server (Debugging Only)
 
 ```bash
 npx zeabur@latest server ssh <server-id>
@@ -73,5 +80,6 @@ echo 'kubectl get pods -A; kubectl get svc -A' | npx zeabur@latest server ssh <s
 
 ## See Also
 
+- `zeabur-deploy` — deploy services to a server's project (do NOT use SSH for deployment)
 - `zeabur-server-catalog` — browse available servers to rent
 - `zeabur-server-rent` — rent a new dedicated server


### PR DESCRIPTION
## Summary
- When users ask to deploy to a specific dedicated server (e.g. "deploy to my AWS Tokyo server"), the agent would SSH into the server to check for web servers instead of using the Zeabur CLI deploy flow
- Root cause: no skill explained the server↔project binding (`Region.ID` = `server-<server-id>`) or guided the agent away from SSH for deployment
- **`zeabur-deploy`**: added "Deploying to a Specific Dedicated Server" section with step-by-step instructions to find the matching project
- **`zeabur-server-list`**: added "Servers and Projects" section, marked SSH as debugging-only, added `zeabur-deploy` to See Also

## Test plan
- [ ] Ask the agent to "deploy X to my [provider] [location] server" and verify it uses `project list --json` + `Region.ID` matching instead of SSH
- [ ] Verify SSH-related tasks (e.g. "check kubectl on my server") still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced dedicated server deployment instructions with clear guidance on mapping servers to Zeabur projects and establishing the proper deployment workflow.
  * Clarified that production deployments should use automated deployment methods rather than manual SSH-based approaches.
  * Designated SSH access for debugging and troubleshooting purposes only, not for production deployment or service management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->