### PR TITLE
feat: add zeabur-auth skill for login, logout, and status check

### DIFF
--- a/skills/zeabur-auth/SKILL.md
+++ b/skills/zeabur-auth/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: zeabur-auth
+description: Use when logging in, logging out, or checking Zeabur auth status. Use when user says "login", "log in", "登入", "logout", "log out", "登出", "auth status", "am I logged in", or "who am I".
+---
+
+# Zeabur Authentication
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Login
+
+Run the login command directly — the CLI will automatically open the browser for the user:
+
+```bash
+npx zeabur@latest auth login -i=false
+```
+
+Login with a token (for CI/CD or headless environments):
+
+```bash
+npx zeabur@latest auth login --token <token> -i=false
+```
+
+## Check Login Status
+
+```bash
+npx zeabur@latest auth status -i=false
+```
+
+## Logout
+
+```bash
+npx zeabur@latest auth logout -i=false
+```
+
+## Tips
+
+- **Never ask the user to run the login command themselves** — run it directly and let the CLI auto-open the browser
+- Token-based login is useful for CI/CD or headless environments
+- Run `auth status` first to check if the user is already logged in before suggesting login


### PR DESCRIPTION
## Summary
- Add new `zeabur-auth` skill that handles login, logout, and auth status check
- Triggers on keywords like "login", "登入", "logout", "登出", "auth status"
- Runs `auth login` directly so the CLI auto-opens the browser — never asks the user to run it themselves

## Test plan
- [ ] Verify skill triggers on "幫我登入 Zeabur"
- [ ] Verify `npx zeabur@latest auth login -i=false` opens browser correctly
- [ ] Verify `auth status` and `auth logout` commands work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added skill documentation for Zeabur authentication, covering login with token-based and interactive options, authentication status verification, and logout functionality.
  * Included usage guidelines to guide proper implementation of authentication workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->