### PR TITLE
feat: add OpenAI Codex support

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.14.0",
+  "version": "1.16.0",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,27 @@ Zeabur Agent Skills — a plugin providing CLI-based skills for managing Zeabur 
 - `.claude-plugin/plugin.json` — Claude Code plugin manifest
 - `skills/<skill-name>/SKILL.md` — Each skill is a standalone markdown file with YAML frontmatter (`name`, `description`) followed by structured documentation
 
+### Skill Categories
+
+| Category | Skills |
+|----------|--------|
+| Deployment & Logs | `zeabur-deploy`, `zeabur-deployment-logs`, `zeabur-template-deploy`, `zeabur-template-backup` |
+| Service Management | `zeabur-service-list`, `zeabur-service-delete`, `zeabur-service-exec`, `zeabur-service-metric`, `zeabur-restart`, `zeabur-update-service`, `zeabur-variables` |
+| Server Management | `zeabur-server-list`, `zeabur-server-catalog`, `zeabur-server-rent` |
+| Project Management | `zeabur-project-create`, `zeabur-project-delete` |
+| Domain & Email | `zeabur-domain-register`, `zeabur-domain-dns`, `zeabur-domain-url`, `zeabur-email` |
+| AI Hub | `zeabur-ai-hub` |
+| Auth | `zeabur-auth` |
+| Troubleshooting | `zeabur-migration`, `zeabur-port-mismatch`, `zeabur-startup-order` |
+
+### Skill Structure Patterns
+
+Skills follow two main patterns:
+
+- **Troubleshooting skills**: symptom/problem → root cause → solution with bash commands → examples/tips
+- **Management/action skills**: prerequisites → workflow steps → CLI commands → error handling
+
 ## Conventions
 
 - **Skill file naming**: `SKILL.md` inside a kebab-case directory prefixed with `zeabur-`
 - **CLI commands**: All skills use `npx zeabur@latest` as the CLI entry point
-- **Skill structure**: YAML frontmatter → symptom/problem → root cause → solution with bash commands → examples/tips


### PR DESCRIPTION
## Summary
- Add `.codex-plugin/plugin.json` manifest for Codex compatibility
- Add `AGENTS.md` (Codex equivalent of `CLAUDE.md`)
- Skills (SKILL.md) are cross-platform — same format works with both Claude Code and Codex

This makes the plugin installable on both Claude Code and OpenAI Codex without maintaining separate repos.

## Test plan
- [ ] Install as Claude Code plugin — verify skills still work
- [ ] Install as Codex plugin — verify skills load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Zeabur Codex plugin with Read/Write capabilities, enabling AI-assisted workflows for deploying projects, listing servers, and renting servers.

* **Documentation**
  * Added a comprehensive developer guide describing plugin architecture, skill organization and naming conventions, documentation patterns, and a unified CLI entry point for working with Zeabur agent skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->