### PR TITLE
fix(update-service): remove outdated variable update caveat

### DIFF
--- a/skills/zeabur-update-service/SKILL.md
+++ b/skills/zeabur-update-service/SKILL.md
@@ -16,10 +16,15 @@ npx zeabur@latest service list --project-id <project-id> -i=false
 # 2. Check current variables
 npx zeabur@latest variable list --id <service-id> -i=false
 
-# 3. Add/update variables
+# 3a. Add new variables (errors if key already exists)
 npx zeabur@latest variable create --id <service-id> \
   --key "KEY1=value1" \
   --key "KEY2=value2" \
+  -i=false -y
+
+# 3b. Update existing variables (only updates specified keys)
+npx zeabur@latest variable update --id <service-id> \
+  --key "KEY1=new_value1" \
   -i=false -y
 
 # 4. Restart service (use the `zeabur-restart` skill for details)
@@ -31,7 +36,6 @@ npx zeabur@latest service restart --id <service-id> -y -i=false
 | Issue | Solution |
 |-------|----------|
 | `${VAR}` references | Set in Dashboard, not CLI (shell expands to empty) |
-| `variable update` clears vars | Use `variable create` instead |
 
 ## Update Image Tag (Upgrade Service Version)
 


### PR DESCRIPTION
## Summary

- Remove the outdated caveat "`variable update` clears vars — Use `variable create` instead" from `zeabur-update-service` skill
- The underlying CLI bug was fixed in [zeabur/cli#196](https://github.com/zeabur/cli/pull/196) — `variable update` now correctly fetches existing variables and merges, so it no longer clears unspecified keys
- The `zeabur-variables` skill already correctly documents this post-fix behavior ("Updates only the specified keys. **Does NOT clear other variables.**"), but `zeabur-update-service` still had the stale warning, causing a contradiction between skills
- Split the workflow example into separate `create` / `update` steps to clarify when to use each subcommand

## Context

PR #31 in this repo attempted to fix the same docs from the opposite direction (documenting the bug as expected behavior), but was correctly closed by @yuaanlin because the CLI bug was fixed. However, the outdated caveat was never removed from `zeabur-update-service`.

## Test plan
- [x] Verified `variable update` only updates specified keys (confirmed via zeabur/cli#196 fix)
- [x] Confirmed `zeabur-variables` skill already documents correct behavior
- [x] No other skills reference the outdated caveat

🤖 Generated with [Claude Code](https://claude.com/claude-code)