### PR TITLE
docs(deployment-logs): document deploymentID auto-resolution behavior

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zeabur",
   "description": "Zeabur CLI skills for deployment, template management, and troubleshooting",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "author": {
     "name": "Can"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/skills/zeabur-deployment-logs/SKILL.md
+++ b/skills/zeabur-deployment-logs/SKILL.md
@@ -20,14 +20,37 @@ npx zeabur@latest deployment log --service-id <service-id> -t runtime -i=false 2
 ## Log Types
 
 ```bash
-# Runtime logs
+# Runtime logs (CLI auto-resolves the latest deployment if needed)
 npx zeabur@latest deployment log --service-id <id> -t runtime -i=false
 
-# Build logs
+# Runtime logs for a specific deployment
+npx zeabur@latest deployment log --service-id <id> --deployment-id <deployment-id> -t runtime -i=false
+
+# Build logs (CLI auto-resolves the latest deployment if needed)
 npx zeabur@latest deployment log --service-id <id> -t build -i=false
+
+# Build logs for a specific deployment
+npx zeabur@latest deployment log --deployment-id <deployment-id> -t build -i=false
 
 # Watch logs (live tail)
 npx zeabur@latest deployment log --service-id <id> -w -i=false
+```
+
+## DeploymentID Behavior
+
+The CLI automatically resolves the latest deployment when `--deployment-id` is not provided:
+
+| Scenario | What happens |
+|----------|-------------|
+| Git/Upload service, no `--deployment-id` | CLI auto-resolves latest deployment → logs returned |
+| Pure image service (e.g. Docker image), runtime log | No deployment exists → falls back to prebuilt query → logs returned |
+| Pure image service, build log | No deployment exists → returns error (image services have no build logs) |
+| Explicit `--deployment-id` provided | Uses the provided ID directly, no auto-resolution |
+
+Use `--deployment-id` when you need logs from a **specific** deployment (not the latest). List deployments with:
+
+```bash
+npx zeabur@latest deployment list --service-id <service-id> -i=false
 ```
 
 ## Tips


### PR DESCRIPTION
## Summary
- Document that CLI v0.14.2+ auto-resolves `--deployment-id` when not provided
- Add table explaining behavior for different service types (git/upload vs pure image)
- Add examples for querying specific deployments and listing deployments
- Bump version to 1.16.1

## Context
CLI fix: https://github.com/zeabur/cli/pull/224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated plugin versions to 1.16.1

* **Documentation**
  * Clarified deployment log commands and behavior for runtime vs build logs
  * Added examples for fetching logs for specific deployments
  * Documented fallback and error behaviors across service types and when deployment IDs are omitted
<!-- end of auto-generated comment: release notes by coderabbit.ai -->