### PR TITLE
feat: add database and object storage deployment skills

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zeabur",
   "description": "Zeabur CLI skills for deployment, template management, and troubleshooting",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "author": {
     "name": "Can"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zeabur",
   "description": "Zeabur CLI skills for deployment, template management, and troubleshooting",
-  "version": "1.16.1",
+  "version": "1.17.0",
   "author": {
     "name": "Can"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.16.1",
+  "version": "1.18.0",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Zeabur Claude Plugin — a Claude Code plugin providing CLI-based skills for man
 |----------|--------|
 | Deployment & Logs | `zeabur-deploy`, `zeabur-dockerfile`, `zeabur-deployment-logs`, `zeabur-template-deploy`, `zeabur-template-backup` |
 | Service Management | `zeabur-service-list`, `zeabur-restart`, `zeabur-update-service`, `zeabur-variables` |
+| Database & Storage | `zeabur-database`, `zeabur-object-storage` |
 | Server Management | `zeabur-server-list`, `zeabur-server-catalog`, `zeabur-server-rent` |
 | Project Management | `zeabur-project-create` |
 | Domain Registration | `zeabur-domain-register`, `zeabur-domain-dns` |

--- a/skills/zeabur-database/SKILL.md
+++ b/skills/zeabur-database/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-database
-description: Use when deploying a database to Zeabur. Use when user needs MySQL, PostgreSQL, MongoDB, or Redis. Use when user says "I need a database", "add database", "deploy postgres", "set up MySQL", "add Redis", "add MongoDB", or "connect to database". Also use when integrating a database with an existing service.
+description: Use when deploying a database to Zeabur. Use when user needs MySQL, PostgreSQL, MongoDB, or Redis. Use when user says "I need a database", "add database", "deploy postgres", "set up MySQL", "add Redis", "add MongoDB", or "connect to database". Also use when user mentions data persistence issues like "data lost after restart", "data not saved", "data disappears", "need persistent storage for data", or "how to persist data". Also use when integrating a database with an existing service.
 ---
 
 # Zeabur Database Deployment

--- a/skills/zeabur-database/SKILL.md
+++ b/skills/zeabur-database/SKILL.md
@@ -3,128 +3,128 @@ name: zeabur-database
 description: Use when deploying a database to Zeabur. Use when user needs MySQL, PostgreSQL, MongoDB, or Redis. Use when user says "I need a database", "add database", "deploy postgres", "set up MySQL", "add Redis", "add MongoDB", or "connect to database". Also use when user mentions data persistence issues like "data lost after restart", "data not saved", "data disappears", "need persistent storage for data", or "how to persist data". Also use when integrating a database with an existing service.
 ---
 
-# Zeabur Database Deployment
+# Zeabur Database Deployment & Integration
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
 
-Deploy a database (PostgreSQL, MySQL, MongoDB, or Redis) to the user's Zeabur project via an existing template, then help them integrate it with their application.
+## Deploy a Database
 
-## Step 1 — Identify What the User Needs
-
-| User Need | Search Keyword |
-|-----------|---------------|
-| Relational DB, SQL, ORM | `postgresql` |
-| MySQL-compatible, WordPress, legacy apps | `mysql` |
-| Document store, JSON, NoSQL | `mongodb` |
-| Cache, session store, queue, pub/sub | `redis` |
-
-If the user doesn't specify, **ask which database they need** rather than guessing.
-
-## Step 2 — Find the Template
-
-Search for existing database templates on Zeabur:
+Search and deploy a database template:
 
 ```bash
+# Search for a database template (postgresql, mysql, mongodb, redis)
 npx zeabur@latest template search postgresql -i=false --json
-```
 
-This returns a JSON array of matching templates. Pick the one with the highest deployment count (more battle-tested). Note the `code` field — you'll need it to deploy.
-
-To inspect a template's full YAML (service definitions, env vars, volumes, etc.):
-
-```bash
+# Inspect a template's full definition (env vars, volumes, ports)
 npx zeabur@latest template get -c <TEMPLATE_CODE> --raw
-```
 
-> For advanced customization or creating a template from scratch, use the `zeabur-template` skill.
-
-## Step 3 — Identify the Target Project
-
-The database must be deployed into a project. Use the `zeabur-service-list` skill or ask the user for their project ID.
-
-```bash
-npx zeabur@latest service list --project-id <project-id>
-```
-
-## Step 4 — Deploy the Template
-
-Deploy the database template into the user's project:
-
-```bash
+# Deploy to the user's project
 npx zeabur@latest template deploy -c <TEMPLATE_CODE> -i=false --project-id <project-id>
 ```
 
-## Step 5 — Integrate with Application
+Pick the template with the highest deployment count. If the user doesn't specify a database, **ask** rather than guessing.
 
-After deploying, the database exposes connection variables that other services can reference. Use the `zeabur-variables` skill to set env vars on the application service.
+> For creating a custom database template from scratch, use the `zeabur-template` skill.
 
-### Connection Variables by Database
+---
 
-| Database | Variable | Example Value |
-|----------|----------|---------------|
-| PostgreSQL | `POSTGRES_CONNECTION_STRING` | `postgresql://postgres:xxx@postgresql.zeabur.internal:5432/mydb` |
-| MySQL | `MYSQL_CONNECTION_STRING` | `mysql://root:xxx@mysql.zeabur.internal:3306/mydb` |
-| MongoDB | `MONGO_CONNECTION_STRING` | `mongodb://root:xxx@mongodb.zeabur.internal:27017` |
-| Redis | `REDIS_URI` | `redis://redis.zeabur.internal:6379` |
+## Retrieve Connection Parameters
 
-> **Note:** The actual variable names depend on the template. Use `npx zeabur@latest template get -c <TEMPLATE_CODE> --raw` to check the exact env var names exposed by the template.
+After deploying, list the database service's variables to get the actual connection info:
 
-### Common Application Env Var Names
+```bash
+npx zeabur@latest variable list --id <database-service-id> -i=false
+```
 
-Map the database connection string to whatever env var your app framework expects:
+Common variables exposed by database templates:
 
-| Framework / App | Env Var Name | Value to Set |
-|-----------------|-------------|--------------|
-| Django | `DATABASE_URL` | `${POSTGRESQL.POSTGRES_CONNECTION_STRING}` |
-| Rails | `DATABASE_URL` | `${POSTGRESQL.POSTGRES_CONNECTION_STRING}` |
-| Laravel | `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD` | Individual vars from the database service |
-| Prisma | `DATABASE_URL` | `${POSTGRESQL.POSTGRES_CONNECTION_STRING}` or `${MYSQL.MYSQL_CONNECTION_STRING}` |
-| Next.js / Node | `DATABASE_URL` | Connection string from chosen database |
-| Spring Boot | `SPRING_DATASOURCE_URL` | `jdbc:postgresql://${POSTGRESQL.POSTGRES_HOST}:${POSTGRESQL.POSTGRES_PORT}/${POSTGRESQL.POSTGRES_DB}` |
-| Redis clients | `REDIS_URL` or `REDIS_URI` | `${REDIS.REDIS_URI}` |
-| Mongoose | `MONGODB_URI` | `${MONGODB.MONGO_CONNECTION_STRING}` |
+| Database | Key Variables | Example Values |
+|----------|--------------|----------------|
+| PostgreSQL | `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_CONNECTION_STRING` | `postgresql://postgres:xxx@postgresql.zeabur.internal:5432/mydb` |
+| MySQL | `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_ROOT_PASSWORD`, `MYSQL_DATABASE`, `MYSQL_CONNECTION_STRING` | `mysql://root:xxx@mysql.zeabur.internal:3306/mydb` |
+| MongoDB | `MONGO_HOST`, `MONGO_PORT`, `MONGO_INITDB_ROOT_USERNAME`, `MONGO_INITDB_ROOT_PASSWORD`, `MONGO_CONNECTION_STRING` | `mongodb://root:xxx@mongodb.zeabur.internal:27017` |
+| Redis | `REDIS_HOST`, `REDIS_PORT`, `REDIS_URI` | `redis://redis.zeabur.internal:6379` |
 
-> **Cross-service variable references** (e.g., `${POSTGRESQL.POSTGRES_CONNECTION_STRING}`) should be set via the Zeabur Dashboard or GraphQL API — the CLI has a known issue with `${}` expansion. See the `zeabur-variables` skill for details.
+> **Variable names depend on the template.** Always run `variable list` to confirm the actual keys.
 
-## Step 6 — Verify
+---
 
-1. Check that the database service is running:
-   ```bash
-   npx zeabur@latest deployment log --service-id <database-service-id>
-   ```
+## Integrate with Application
 
-2. Test connectivity from the application container:
-   ```bash
-   # PostgreSQL
-   npx zeabur@latest service exec --id <app-service-id> -- nc -z postgresql.zeabur.internal 5432
+### Cross-service variable references
 
-   # MySQL
-   npx zeabur@latest service exec --id <app-service-id> -- nc -z mysql.zeabur.internal 3306
+In Zeabur, services can reference other services' exposed variables using the `${SERVICE_NAME.VAR_NAME}` syntax. For example, if the database service is named `postgresql`:
 
-   # MongoDB
-   npx zeabur@latest service exec --id <app-service-id> -- nc -z mongodb.zeabur.internal 27017
+```
+${POSTGRESQL.POSTGRES_CONNECTION_STRING}
+```
 
-   # Redis
-   npx zeabur@latest service exec --id <app-service-id> -- nc -z redis.zeabur.internal 6379
-   ```
+> **CLI limitation:** The CLI has a known bug with `${}` expansion — cross-service references should be set via the **Zeabur Dashboard** or GraphQL API. See the `zeabur-variables` skill for details.
 
-3. If the app fails to connect, check the `zeabur-startup-order` skill — the database may not be ready when the app starts.
+### Common framework env var mapping
 
-## Tips
+| Framework / App | Env Var to Set | Value |
+|-----------------|---------------|-------|
+| Django, Rails, Prisma, Next.js | `DATABASE_URL` | `${POSTGRESQL.POSTGRES_CONNECTION_STRING}` or `${MYSQL.MYSQL_CONNECTION_STRING}` |
+| Laravel | `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD` | Individual vars from database service |
+| Spring Boot (PostgreSQL) | `SPRING_DATASOURCE_URL` | `jdbc:postgresql://${POSTGRESQL.POSTGRES_HOST}:${POSTGRESQL.POSTGRES_PORT}/${POSTGRESQL.POSTGRES_DB}` |
+| Spring Boot (MySQL) | `SPRING_DATASOURCE_URL` | `jdbc:mysql://${MYSQL.MYSQL_HOST}:${MYSQL.MYSQL_PORT}/${MYSQL.MYSQL_DATABASE}` |
+| Mongoose / Node.js | `MONGODB_URI` | `${MONGODB.MONGO_CONNECTION_STRING}` |
+| Redis clients (ioredis, redis-py, etc.) | `REDIS_URL` | `${REDIS.REDIS_URI}` |
 
-- **External access:** Databases use TCP ports. Port forwarding is auto-enabled. Get the external host:port with `npx zeabur@latest service network --id <service-id>`.
-- **Data persistence:** Database templates include volumes. Data survives restarts and redeployments.
-- **Run queries:** Use the `zeabur-service-exec` skill to run database clients inside the container:
-  ```bash
-  # PostgreSQL
-  npx zeabur@latest service exec --id <db-service-id> -- psql -U postgres -d mydb
+---
 
-  # MySQL
-  npx zeabur@latest service exec --id <db-service-id> -- mysql -u root -p
+## Local Connection (Port Forwarding)
 
-  # MongoDB
-  npx zeabur@latest service exec --id <db-service-id> -- mongosh -u root -p
+Database ports are TCP with port forwarding auto-enabled. To get the external host:port for local tools:
 
-  # Redis
-  npx zeabur@latest service exec --id <db-service-id> -- redis-cli
-  ```
+```bash
+npx zeabur@latest service network --id <database-service-id>
+```
+
+This returns `PORT_FORWARDED_HOSTNAME` and the forwarded port. Use them to connect from local tools:
+
+```bash
+# PostgreSQL (psql)
+psql "postgresql://postgres:PASSWORD@FORWARDED_HOST:FORWARDED_PORT/mydb"
+
+# MySQL (mysql)
+mysql -h FORWARDED_HOST -P FORWARDED_PORT -u root -p mydb
+
+# MongoDB (mongosh)
+mongosh "mongodb://root:PASSWORD@FORWARDED_HOST:FORWARDED_PORT"
+
+# Redis (redis-cli)
+redis-cli -h FORWARDED_HOST -p FORWARDED_PORT
+```
+
+You can also connect from GUI tools (DBeaver, TablePlus, pgAdmin, MongoDB Compass, RedisInsight, etc.) using the same forwarded host:port.
+
+---
+
+## Run Queries Inside the Container
+
+Use the `zeabur-service-exec` skill to run database clients directly:
+
+```bash
+# PostgreSQL
+npx zeabur@latest service exec --id <db-service-id> -- psql -U postgres -d mydb
+
+# MySQL
+npx zeabur@latest service exec --id <db-service-id> -- mysql -u root -p
+
+# MongoDB
+npx zeabur@latest service exec --id <db-service-id> -- mongosh -u root -p
+
+# Redis
+npx zeabur@latest service exec --id <db-service-id> -- redis-cli
+```
+
+---
+
+## Caveats
+
+1. **Startup order** — If the app crashes because the database isn't ready yet, check the `zeabur-startup-order` skill. Add `healthCheck` and `dependencies` in the template to enforce ordering.
+2. **Data persistence** — Database templates include volumes. Data survives restarts and redeployments. If a user reports data loss, verify the template has a `volumes` section.
+3. **Connection refused from app** — The internal hostname follows the pattern `<service-name>.zeabur.internal`. If the service was renamed or uses a non-default name, the hostname changes accordingly. Use `variable list` to check `*_HOST`.
+4. **Password contains special characters** — The auto-generated `${PASSWORD}` may contain characters that break connection string parsing (e.g., `@`, `/`, `%`). If the app fails to parse the URL, URL-encode the password or pass host/port/user/password as separate env vars instead of a single connection string.

--- a/skills/zeabur-database/SKILL.md
+++ b/skills/zeabur-database/SKILL.md
@@ -84,24 +84,26 @@ Exposed variables from the official Zeabur templates:
 
 ### Cross-service variable references
 
-In Zeabur, services can reference other services' exposed variables using the `${SERVICE_NAME.VAR_NAME}` syntax. For example, if the database service is named `postgresql`:
+Zeabur uses a **flat variable namespace** — all exposed variables from every service in the same project are merged together. Your app can reference them directly by name, no service prefix needed:
 
 ```
-${POSTGRESQL.POSTGRES_CONNECTION_STRING}
+${POSTGRES_CONNECTION_STRING}
 ```
 
-> **CLI limitation:** The CLI has a known bug with `${}` expansion — cross-service references should be set via the **Zeabur Dashboard** or GraphQL API. See the `zeabur-variables` skill for details.
+> **CLI limitation:** The CLI has a known bug with `${}` expansion — variable references should be set via the **Zeabur Dashboard**. See the `zeabur-variables` skill for details.
+
+> **Name collision:** If multiple services expose the same variable name (e.g., two PostgreSQL instances both expose `POSTGRES_HOST`), the value may be unpredictable. In that case, manually specify the hostname and port from the service's Networking tab.
 
 ### Common framework env var mapping
 
 | Framework / App | Env Var to Set | Value |
 |-----------------|---------------|-------|
-| Django, Rails, Prisma, Next.js | `DATABASE_URL` | `${POSTGRESQL.POSTGRES_CONNECTION_STRING}` or construct MySQL URL manually |
-| Laravel | `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD` | Individual vars from database service |
-| Spring Boot (PostgreSQL) | `SPRING_DATASOURCE_URL` | `jdbc:postgresql://${POSTGRESQL.POSTGRES_HOST}:${POSTGRESQL.POSTGRES_PORT}/${POSTGRESQL.POSTGRES_DATABASE}` |
-| Spring Boot (MySQL) | `SPRING_DATASOURCE_URL` | `jdbc:mysql://${MYSQL.MYSQL_HOST}:${MYSQL.MYSQL_PORT}/${MYSQL.MYSQL_DATABASE}` |
-| Mongoose / Node.js | `MONGODB_URI` | `${MONGODB.MONGO_CONNECTION_STRING}` |
-| Redis clients (ioredis, redis-py, etc.) | `REDIS_URL` | `${REDIS.REDIS_CONNECTION_STRING}` |
+| Django, Rails, Prisma, Next.js | `DATABASE_URL` | `${POSTGRES_CONNECTION_STRING}` or construct MySQL URL manually |
+| Laravel | `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD` | `${MYSQL_HOST}`, `${MYSQL_PORT}`, etc. |
+| Spring Boot (PostgreSQL) | `SPRING_DATASOURCE_URL` | `jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}` |
+| Spring Boot (MySQL) | `SPRING_DATASOURCE_URL` | `jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}` |
+| Mongoose / Node.js | `MONGODB_URI` | `${MONGO_CONNECTION_STRING}` |
+| Redis clients (ioredis, redis-py, etc.) | `REDIS_URL` | `${REDIS_CONNECTION_STRING}` |
 
 ---
 

--- a/skills/zeabur-database/SKILL.md
+++ b/skills/zeabur-database/SKILL.md
@@ -29,16 +29,54 @@ After deploying, list the database service's variables to get the actual connect
 npx zeabur@latest variable list --id <database-service-id> -i=false
 ```
 
-Common variables exposed by database templates:
+Exposed variables from the official Zeabur templates:
 
-| Database | Key Variables | Example Values |
-|----------|--------------|----------------|
-| PostgreSQL | `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_CONNECTION_STRING` | `postgresql://postgres:xxx@postgresql.zeabur.internal:5432/mydb` |
-| MySQL | `MYSQL_HOST`, `MYSQL_PORT`, `MYSQL_ROOT_PASSWORD`, `MYSQL_DATABASE`, `MYSQL_CONNECTION_STRING` | `mysql://root:xxx@mysql.zeabur.internal:3306/mydb` |
-| MongoDB | `MONGO_HOST`, `MONGO_PORT`, `MONGO_INITDB_ROOT_USERNAME`, `MONGO_INITDB_ROOT_PASSWORD`, `MONGO_CONNECTION_STRING` | `mongodb://root:xxx@mongodb.zeabur.internal:27017` |
-| Redis | `REDIS_HOST`, `REDIS_PORT`, `REDIS_URI` | `redis://redis.zeabur.internal:6379` |
+### PostgreSQL (template code: `B20CX0`)
 
-> **Variable names depend on the template.** Always run `variable list` to confirm the actual keys.
+| Variable | Description |
+|----------|-------------|
+| `POSTGRES_USERNAME` | Username (default: `root`) |
+| `POSTGRES_PASSWORD` | Password (auto-generated) |
+| `POSTGRES_HOST` | Internal hostname |
+| `POSTGRES_PORT` | Port (`5432`) |
+| `POSTGRES_DATABASE` | Database name (default: `zeabur`) |
+| `POSTGRES_CONNECTION_STRING` | `postgresql://username:password@host:port/database` |
+| `POSTGRES_URI` | Same as `POSTGRES_CONNECTION_STRING` |
+
+### MySQL (template code: `DGLGRG`)
+
+| Variable | Description |
+|----------|-------------|
+| `MYSQL_USERNAME` | Username (default: `root`) |
+| `MYSQL_PASSWORD` | Password (auto-generated) |
+| `MYSQL_HOST` | Internal hostname |
+| `MYSQL_PORT` | Port (`3306`) |
+| `MYSQL_DATABASE` | Database name (default: `zeabur`) |
+
+> **Note:** The official MySQL template does not expose a connection string variable. Construct it manually: `mysql://${MYSQL_USERNAME}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}`
+
+### MongoDB (template code: `KXL04P`)
+
+| Variable | Description |
+|----------|-------------|
+| `MONGO_USERNAME` | Username (default: `mongo`) |
+| `MONGO_PASSWORD` | Password (auto-generated) |
+| `MONGO_HOST` | Internal hostname |
+| `MONGO_PORT` | Port (`27017`) |
+| `MONGO_CONNECTION_STRING` | `mongodb://username:password@host:port` |
+| `MONGO_URI` | Same as `MONGO_CONNECTION_STRING` |
+
+### Redis (template code: `KQZHXT`)
+
+| Variable | Description |
+|----------|-------------|
+| `REDIS_PASSWORD` | Password (auto-generated) |
+| `REDIS_HOST` | Internal hostname |
+| `REDIS_PORT` | Port (`6379`) |
+| `REDIS_CONNECTION_STRING` | `redis://:password@host:port` |
+| `REDIS_URI` | Same as `REDIS_CONNECTION_STRING` |
+
+> **Variable names may differ across templates.** The above are from the official Zeabur templates. Always run `variable list` to confirm the actual keys.
 
 ---
 
@@ -58,12 +96,12 @@ ${POSTGRESQL.POSTGRES_CONNECTION_STRING}
 
 | Framework / App | Env Var to Set | Value |
 |-----------------|---------------|-------|
-| Django, Rails, Prisma, Next.js | `DATABASE_URL` | `${POSTGRESQL.POSTGRES_CONNECTION_STRING}` or `${MYSQL.MYSQL_CONNECTION_STRING}` |
+| Django, Rails, Prisma, Next.js | `DATABASE_URL` | `${POSTGRESQL.POSTGRES_CONNECTION_STRING}` or construct MySQL URL manually |
 | Laravel | `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD` | Individual vars from database service |
-| Spring Boot (PostgreSQL) | `SPRING_DATASOURCE_URL` | `jdbc:postgresql://${POSTGRESQL.POSTGRES_HOST}:${POSTGRESQL.POSTGRES_PORT}/${POSTGRESQL.POSTGRES_DB}` |
+| Spring Boot (PostgreSQL) | `SPRING_DATASOURCE_URL` | `jdbc:postgresql://${POSTGRESQL.POSTGRES_HOST}:${POSTGRESQL.POSTGRES_PORT}/${POSTGRESQL.POSTGRES_DATABASE}` |
 | Spring Boot (MySQL) | `SPRING_DATASOURCE_URL` | `jdbc:mysql://${MYSQL.MYSQL_HOST}:${MYSQL.MYSQL_PORT}/${MYSQL.MYSQL_DATABASE}` |
 | Mongoose / Node.js | `MONGODB_URI` | `${MONGODB.MONGO_CONNECTION_STRING}` |
-| Redis clients (ioredis, redis-py, etc.) | `REDIS_URL` | `${REDIS.REDIS_URI}` |
+| Redis clients (ioredis, redis-py, etc.) | `REDIS_URL` | `${REDIS.REDIS_CONNECTION_STRING}` |
 
 ---
 
@@ -79,16 +117,16 @@ This returns `PORT_FORWARDED_HOSTNAME` and the forwarded port. Use them to conne
 
 ```bash
 # PostgreSQL (psql)
-psql "postgresql://postgres:PASSWORD@FORWARDED_HOST:FORWARDED_PORT/mydb"
+psql "postgresql://root:PASSWORD@FORWARDED_HOST:FORWARDED_PORT/zeabur"
 
 # MySQL (mysql)
-mysql -h FORWARDED_HOST -P FORWARDED_PORT -u root -p mydb
+mysql -h FORWARDED_HOST -P FORWARDED_PORT -u root -p zeabur
 
 # MongoDB (mongosh)
-mongosh "mongodb://root:PASSWORD@FORWARDED_HOST:FORWARDED_PORT"
+mongosh "mongodb://mongo:PASSWORD@FORWARDED_HOST:FORWARDED_PORT"
 
 # Redis (redis-cli)
-redis-cli -h FORWARDED_HOST -p FORWARDED_PORT
+redis-cli -h FORWARDED_HOST -p FORWARDED_PORT -a PASSWORD
 ```
 
 You can also connect from GUI tools (DBeaver, TablePlus, pgAdmin, MongoDB Compass, RedisInsight, etc.) using the same forwarded host:port.
@@ -101,16 +139,16 @@ Use the `zeabur-service-exec` skill to run database clients directly:
 
 ```bash
 # PostgreSQL
-npx zeabur@latest service exec --id <db-service-id> -- psql -U postgres -d mydb
+npx zeabur@latest service exec --id <db-service-id> -- psql -U root -d zeabur
 
 # MySQL
-npx zeabur@latest service exec --id <db-service-id> -- mysql -u root -p
+npx zeabur@latest service exec --id <db-service-id> -- mysql -u root -p zeabur
 
 # MongoDB
-npx zeabur@latest service exec --id <db-service-id> -- mongosh -u root -p
+npx zeabur@latest service exec --id <db-service-id> -- mongosh -u mongo -p
 
 # Redis
-npx zeabur@latest service exec --id <db-service-id> -- redis-cli
+npx zeabur@latest service exec --id <db-service-id> -- redis-cli -a PASSWORD
 ```
 
 ---

--- a/skills/zeabur-database/SKILL.md
+++ b/skills/zeabur-database/SKILL.md
@@ -21,157 +21,167 @@ Pick the template with the highest deployment count. If the user doesn't specify
 
 ---
 
-## Retrieve Connection Parameters
+## After Deployment: How to Connect
 
-After deploying, list the database service's variables to get the actual connection info:
+For any database, you need two pieces of information: **how to connect** (hostname + port) and **how to authenticate** (username + password + database name).
+
+### How to connect — `service network`
+
+```bash
+npx zeabur@latest service network --id <database-service-id> -i=false
+```
+
+This shows:
+- **Private Networking** — internal `hostname:port` for inter-service access (e.g., `mysql.zeabur.internal:3306`)
+- **Public Networking** — external `host:port` for connecting from your local machine (via port forwarding)
+
+### How to authenticate — `variable list`
 
 ```bash
 npx zeabur@latest variable list --id <database-service-id> -i=false
 ```
 
-Exposed variables from the official Zeabur templates:
+This lists all the credentials (username, password, database name, connection string, etc.) for the database service.
 
-### PostgreSQL (template code: `B20CX0`)
+---
+
+## PostgreSQL
+
+### Credentials (from `variable list`)
 
 | Variable | Description |
 |----------|-------------|
 | `POSTGRES_USERNAME` | Username (default: `root`) |
 | `POSTGRES_PASSWORD` | Password (auto-generated) |
-| `POSTGRES_HOST` | Internal hostname |
-| `POSTGRES_PORT` | Port (`5432`) |
 | `POSTGRES_DATABASE` | Database name (default: `zeabur`) |
-| `POSTGRES_CONNECTION_STRING` | `postgresql://username:password@host:port/database` |
-| `POSTGRES_URI` | Same as `POSTGRES_CONNECTION_STRING` |
+| `POSTGRES_CONNECTION_STRING` | Full connection string |
 
-### MySQL (template code: `DGLGRG`)
+### Connect from local machine
 
-| Variable | Description |
-|----------|-------------|
-| `MYSQL_USERNAME` | Username (default: `root`) |
-| `MYSQL_PASSWORD` | Password (auto-generated) |
-| `MYSQL_HOST` | Internal hostname |
-| `MYSQL_PORT` | Port (`3306`) |
-| `MYSQL_DATABASE` | Database name (default: `zeabur`) |
+```bash
+psql "postgresql://POSTGRES_USERNAME:POSTGRES_PASSWORD@PUBLIC_HOST:PUBLIC_PORT/POSTGRES_DATABASE"
+```
 
-> **Note:** The official MySQL template does not expose a connection string variable. Construct it manually: `mysql://${MYSQL_USERNAME}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}`
+### Connect from app (same project)
 
-### MongoDB (template code: `KXL04P`)
-
-| Variable | Description |
-|----------|-------------|
-| `MONGO_USERNAME` | Username (default: `mongo`) |
-| `MONGO_PASSWORD` | Password (auto-generated) |
-| `MONGO_HOST` | Internal hostname |
-| `MONGO_PORT` | Port (`27017`) |
-| `MONGO_CONNECTION_STRING` | `mongodb://username:password@host:port` |
-| `MONGO_URI` | Same as `MONGO_CONNECTION_STRING` |
-
-### Redis (template code: `KQZHXT`)
-
-| Variable | Description |
-|----------|-------------|
-| `REDIS_PASSWORD` | Password (auto-generated) |
-| `REDIS_HOST` | Internal hostname |
-| `REDIS_PORT` | Port (`6379`) |
-| `REDIS_CONNECTION_STRING` | `redis://:password@host:port` |
-| `REDIS_URI` | Same as `REDIS_CONNECTION_STRING` |
-
-> **Variable names may differ across templates.** The above are from the official Zeabur templates. Always run `variable list` to confirm the actual keys.
-
----
-
-## Integrate with Application
-
-### Cross-service variable references
-
-Zeabur uses a **flat variable namespace** — all exposed variables from every service in the same project are merged together. Your app can reference them directly by name, no service prefix needed:
+Set `DATABASE_URL` on your app service to reference the exposed variable:
 
 ```
 ${POSTGRES_CONNECTION_STRING}
 ```
 
-> **CLI limitation:** The CLI has a known bug with `${}` expansion — variable references should be set via the **Zeabur Dashboard**. See the `zeabur-variables` skill for details.
+Works with Django, Rails, Prisma, Next.js, and any framework that reads `DATABASE_URL`.
 
-> **Name collision:** If multiple services expose the same variable name (e.g., two PostgreSQL instances both expose `POSTGRES_HOST`), the value may be unpredictable. In that case, manually specify the hostname and port from the service's Networking tab.
+For frameworks that need individual vars (e.g., Laravel, Spring Boot):
 
-### Common framework env var mapping
-
-| Framework / App | Env Var to Set | Value |
-|-----------------|---------------|-------|
-| Django, Rails, Prisma, Next.js | `DATABASE_URL` | `${POSTGRES_CONNECTION_STRING}` or construct MySQL URL manually |
-| Laravel | `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD` | `${MYSQL_HOST}`, `${MYSQL_PORT}`, etc. |
-| Spring Boot (PostgreSQL) | `SPRING_DATASOURCE_URL` | `jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}` |
-| Spring Boot (MySQL) | `SPRING_DATASOURCE_URL` | `jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}` |
-| Mongoose / Node.js | `MONGODB_URI` | `${MONGO_CONNECTION_STRING}` |
-| Redis clients (ioredis, redis-py, etc.) | `REDIS_URL` | `${REDIS_CONNECTION_STRING}` |
+```
+DB_HOST=${POSTGRES_HOST}
+DB_PORT=${POSTGRES_PORT}
+DB_USERNAME=${POSTGRES_USERNAME}
+DB_PASSWORD=${POSTGRES_PASSWORD}
+DB_DATABASE=${POSTGRES_DATABASE}
+```
 
 ---
 
-## External Connection (from local machine)
+## MySQL
 
-Database ports are TCP. Use `service instruction` to get the **resolved** external connection info (hostname, port, connection string with real values already substituted):
+### Credentials (from `variable list`)
 
-```bash
-npx zeabur@latest service instruction --id <database-service-id> -i=false
-```
+| Variable | Description |
+|----------|-------------|
+| `MYSQL_USERNAME` | Username (default: `root`) |
+| `MYSQL_PASSWORD` | Password (auto-generated) |
+| `MYSQL_DATABASE` | Database name (default: `zeabur`) |
 
-This outputs ready-to-use values like:
-```
-Connection String: postgresql://root:abc123@xxx.clusters.zeabur.com:12345/zeabur
-PostgreSQL Connect Command: psql "postgresql://root:abc123@xxx.clusters.zeabur.com:12345/zeabur"
-PostgreSQL host: xxx.clusters.zeabur.com
-PostgreSQL port: 12345
-```
+> The official MySQL template does not expose a connection string variable.
 
-Alternatively, use `service network` to get the raw port-forwarding details (only works for TCP/UDP ports):
+### Connect from local machine
 
 ```bash
-npx zeabur@latest service network --id <database-service-id> --json -i=false
+mysql -h PUBLIC_HOST -P PUBLIC_PORT -u MYSQL_USERNAME -p MYSQL_DATABASE
 ```
 
-This returns `portForwardedHost` and each port's `forwardedPort`. Use them to connect from local tools:
+### Connect from app (same project)
 
-```bash
-# PostgreSQL (psql)
-psql "postgresql://root:PASSWORD@FORWARDED_HOST:FORWARDED_PORT/zeabur"
+Construct the connection string manually in your app's env var:
 
-# MySQL (mysql)
-mysql -h FORWARDED_HOST -P FORWARDED_PORT -u root -p zeabur
-
-# MongoDB (mongosh)
-mongosh "mongodb://mongo:PASSWORD@FORWARDED_HOST:FORWARDED_PORT"
-
-# Redis (redis-cli)
-redis-cli -h FORWARDED_HOST -p FORWARDED_PORT -a PASSWORD
+```
+DATABASE_URL=mysql://root:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}
 ```
 
-You can also connect from GUI tools (DBeaver, TablePlus, pgAdmin, MongoDB Compass, RedisInsight, etc.) using the same host:port.
+Or use individual vars:
+
+```
+DB_HOST=${MYSQL_HOST}
+DB_PORT=${MYSQL_PORT}
+DB_USERNAME=${MYSQL_USERNAME}
+DB_PASSWORD=${MYSQL_PASSWORD}
+DB_DATABASE=${MYSQL_DATABASE}
+```
 
 ---
 
-## Run Queries Inside the Container
+## MongoDB
 
-Use the `zeabur-service-exec` skill to run database clients directly:
+### Credentials (from `variable list`)
+
+| Variable | Description |
+|----------|-------------|
+| `MONGO_USERNAME` | Username (default: `mongo`) |
+| `MONGO_PASSWORD` | Password (auto-generated) |
+| `MONGO_CONNECTION_STRING` | Full connection string |
+
+### Connect from local machine
 
 ```bash
-# PostgreSQL
-npx zeabur@latest service exec --id <db-service-id> -- psql -U root -d zeabur
-
-# MySQL
-npx zeabur@latest service exec --id <db-service-id> -- mysql -u root -p zeabur
-
-# MongoDB
-npx zeabur@latest service exec --id <db-service-id> -- mongosh -u mongo -p
-
-# Redis
-npx zeabur@latest service exec --id <db-service-id> -- redis-cli -a PASSWORD
+mongosh "mongodb://MONGO_USERNAME:MONGO_PASSWORD@PUBLIC_HOST:PUBLIC_PORT"
 ```
+
+### Connect from app (same project)
+
+Set `MONGODB_URI` on your app service:
+
+```
+${MONGO_CONNECTION_STRING}
+```
+
+Works with Mongoose, PyMongo, and any MongoDB driver.
+
+---
+
+## Redis
+
+### Credentials (from `variable list`)
+
+| Variable | Description |
+|----------|-------------|
+| `REDIS_PASSWORD` | Password (auto-generated) |
+| `REDIS_CONNECTION_STRING` | Full connection string |
+
+> Redis has no username or database name by default.
+
+### Connect from local machine
+
+```bash
+redis-cli -h PUBLIC_HOST -p PUBLIC_PORT -a REDIS_PASSWORD
+```
+
+### Connect from app (same project)
+
+Set `REDIS_URL` on your app service:
+
+```
+${REDIS_CONNECTION_STRING}
+```
+
+Works with ioredis, redis-py, go-redis, and any Redis client.
 
 ---
 
 ## Caveats
 
-1. **Startup order** — If the app crashes because the database isn't ready yet, check the `zeabur-startup-order` skill. Add `healthCheck` and `dependencies` in the template to enforce ordering.
-2. **Data persistence** — Database templates include volumes. Data survives restarts and redeployments. If a user reports data loss, verify the template has a `volumes` section.
-3. **Connection refused from app** — The internal hostname follows the pattern `<service-name>.zeabur.internal`. If the service was renamed or uses a non-default name, the hostname changes accordingly. Use `variable list` to check `*_HOST`.
-4. **Password contains special characters** — The auto-generated `${PASSWORD}` may contain characters that break connection string parsing (e.g., `@`, `/`, `%`). If the app fails to parse the URL, URL-encode the password or pass host/port/user/password as separate env vars instead of a single connection string.
+1. **Variable references** — Zeabur uses a flat namespace. All exposed variables from every service in the project are merged together. Your app references them directly by name (e.g., `${POSTGRES_HOST}`), no prefix needed. Set them via the **Zeabur Dashboard** — the CLI has a known bug with `${}` expansion.
+2. **Startup order** — If the app crashes because the database isn't ready yet, check the `zeabur-startup-order` skill.
+3. **Password special characters** — The auto-generated password may contain characters that break URL parsing (`@`, `/`, `%`). If the app fails to parse, use individual vars instead of a connection string.
+4. **Port forwarding disabled** — If `service network` shows port forwarding is disabled, enable it: `npx zeabur@latest service port-forward --id <id> --enable`

--- a/skills/zeabur-database/SKILL.md
+++ b/skills/zeabur-database/SKILL.md
@@ -1,0 +1,308 @@
+---
+name: zeabur-database
+description: Use when deploying a database to Zeabur. Use when user needs MySQL, PostgreSQL, MongoDB, or Redis. Use when user says "I need a database", "add database", "deploy postgres", "set up MySQL", "add Redis", "add MongoDB", or "connect to database". Also use when integrating a database with an existing service.
+---
+
+# Zeabur Database Deployment
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+Deploy a database (PostgreSQL, MySQL, MongoDB, or Redis) to the user's Zeabur project via a template YAML, then help them integrate it with their application.
+
+## Step 1 — Identify What the User Needs
+
+| User Need | Database | Default Image |
+|-----------|----------|---------------|
+| Relational DB, SQL, ORM | PostgreSQL | `postgres:16-alpine` |
+| MySQL-compatible, WordPress, legacy apps | MySQL (MariaDB) | `mariadb:10.6` |
+| Document store, JSON, NoSQL | MongoDB | `mongo:8.0` |
+| Cache, session store, queue, pub/sub | Redis | `redis:7-alpine` |
+
+If the user doesn't specify, **ask which database they need** rather than guessing.
+
+## Step 2 — Identify the Target Project
+
+The database must be deployed into a project. Use the `zeabur-service-list` skill or ask the user for their project ID.
+
+```bash
+npx zeabur@latest service list --project-id <project-id>
+```
+
+## Step 3 — Write and Deploy the Template
+
+Create a template YAML file and deploy it to the user's project. Pick the matching template below, save it to a `.yaml` file, then deploy:
+
+```bash
+npx zeabur@latest template deploy -f database.yaml -i=false --project-id <project-id>
+```
+
+### PostgreSQL
+
+```yaml
+# yaml-language-server: $schema=https://schema.zeabur.app/template.json
+apiVersion: zeabur.com/v1
+kind: Template
+metadata:
+  name: PostgreSQL
+spec:
+  description: PostgreSQL relational database
+  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/postgresql.svg
+  tags:
+    - Database
+  variables: []
+  readme: ""
+  services:
+    - name: postgresql
+      icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/postgresql.svg
+      template: PREBUILT_V2
+      spec:
+        source:
+          image: postgres:16-alpine
+        ports:
+          - id: database
+            port: 5432
+            type: TCP
+        volumes:
+          - id: data
+            dir: /var/lib/postgresql/data
+        env:
+          POSTGRES_USER:
+            default: postgres
+            expose: true
+          POSTGRES_PASSWORD:
+            default: ${PASSWORD}
+            expose: true
+          POSTGRES_DB:
+            default: mydb
+            expose: true
+          POSTGRES_HOST:
+            default: ${CONTAINER_HOSTNAME}
+            expose: true
+            readonly: true
+          POSTGRES_PORT:
+            default: ${DATABASE_PORT}
+            expose: true
+            readonly: true
+          POSTGRES_CONNECTION_STRING:
+            default: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+            expose: true
+            readonly: true
+```
+
+### MySQL (MariaDB)
+
+```yaml
+# yaml-language-server: $schema=https://schema.zeabur.app/template.json
+apiVersion: zeabur.com/v1
+kind: Template
+metadata:
+  name: MySQL
+spec:
+  description: MySQL-compatible database (MariaDB)
+  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/mariadb.svg
+  tags:
+    - Database
+  variables: []
+  readme: ""
+  services:
+    - name: mysql
+      icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/mariadb.svg
+      template: PREBUILT_V2
+      spec:
+        source:
+          image: mariadb:10.6
+        ports:
+          - id: database
+            port: 3306
+            type: TCP
+        volumes:
+          - id: data
+            dir: /var/lib/mysql
+        env:
+          MYSQL_ROOT_PASSWORD:
+            default: ${PASSWORD}
+            expose: true
+          MYSQL_DATABASE:
+            default: mydb
+            expose: true
+          MYSQL_HOST:
+            default: ${CONTAINER_HOSTNAME}
+            expose: true
+            readonly: true
+          MYSQL_PORT:
+            default: ${DATABASE_PORT}
+            expose: true
+            readonly: true
+          MYSQL_CONNECTION_STRING:
+            default: mysql://root:${MYSQL_ROOT_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}
+            expose: true
+            readonly: true
+```
+
+### MongoDB
+
+```yaml
+# yaml-language-server: $schema=https://schema.zeabur.app/template.json
+apiVersion: zeabur.com/v1
+kind: Template
+metadata:
+  name: MongoDB
+spec:
+  description: MongoDB document database
+  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/mongodb.svg
+  tags:
+    - Database
+  variables: []
+  readme: ""
+  services:
+    - name: mongodb
+      icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/mongodb.svg
+      template: PREBUILT_V2
+      spec:
+        source:
+          image: mongo:8.0
+        ports:
+          - id: database
+            port: 27017
+            type: TCP
+        volumes:
+          - id: data
+            dir: /data/db
+        env:
+          MONGO_INITDB_ROOT_USERNAME:
+            default: root
+            expose: true
+          MONGO_INITDB_ROOT_PASSWORD:
+            default: ${PASSWORD}
+            expose: true
+          MONGO_HOST:
+            default: ${CONTAINER_HOSTNAME}
+            expose: true
+            readonly: true
+          MONGO_PORT:
+            default: ${DATABASE_PORT}
+            expose: true
+            readonly: true
+          MONGO_CONNECTION_STRING:
+            default: mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}
+            expose: true
+            readonly: true
+```
+
+### Redis
+
+```yaml
+# yaml-language-server: $schema=https://schema.zeabur.app/template.json
+apiVersion: zeabur.com/v1
+kind: Template
+metadata:
+  name: Redis
+spec:
+  description: Redis in-memory data store
+  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/redis.svg
+  tags:
+    - Database
+  variables: []
+  readme: ""
+  services:
+    - name: redis
+      icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/redis.svg
+      template: PREBUILT_V2
+      spec:
+        source:
+          image: redis:7-alpine
+        ports:
+          - id: database
+            port: 6379
+            type: TCP
+        volumes:
+          - id: data
+            dir: /data
+        env:
+          REDIS_HOST:
+            default: ${CONTAINER_HOSTNAME}
+            expose: true
+            readonly: true
+          REDIS_PORT:
+            default: ${DATABASE_PORT}
+            expose: true
+            readonly: true
+          REDIS_URI:
+            default: redis://${REDIS_HOST}:${REDIS_PORT}
+            expose: true
+            readonly: true
+```
+
+## Step 4 — Integrate with Application
+
+After deploying, the database exposes connection variables that other services can reference. Use the `zeabur-variables` skill to set env vars on the application service.
+
+### Connection Variables by Database
+
+| Database | Variable | Example Value |
+|----------|----------|---------------|
+| PostgreSQL | `POSTGRES_CONNECTION_STRING` | `postgresql://postgres:xxx@postgresql.zeabur.internal:5432/mydb` |
+| MySQL | `MYSQL_CONNECTION_STRING` | `mysql://root:xxx@mysql.zeabur.internal:3306/mydb` |
+| MongoDB | `MONGO_CONNECTION_STRING` | `mongodb://root:xxx@mongodb.zeabur.internal:27017` |
+| Redis | `REDIS_URI` | `redis://redis.zeabur.internal:6379` |
+
+### Common Application Env Var Names
+
+Map the database connection string to whatever env var your app framework expects:
+
+| Framework / App | Env Var Name | Value to Set |
+|-----------------|-------------|--------------|
+| Django | `DATABASE_URL` | `${POSTGRESQL.POSTGRES_CONNECTION_STRING}` |
+| Rails | `DATABASE_URL` | `${POSTGRESQL.POSTGRES_CONNECTION_STRING}` |
+| Laravel | `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD` | Individual vars from the database service |
+| Prisma | `DATABASE_URL` | `${POSTGRESQL.POSTGRES_CONNECTION_STRING}` or `${MYSQL.MYSQL_CONNECTION_STRING}` |
+| Next.js / Node | `DATABASE_URL` | Connection string from chosen database |
+| Spring Boot | `SPRING_DATASOURCE_URL` | `jdbc:postgresql://${POSTGRESQL.POSTGRES_HOST}:${POSTGRESQL.POSTGRES_PORT}/${POSTGRESQL.POSTGRES_DB}` |
+| Redis clients | `REDIS_URL` or `REDIS_URI` | `${REDIS.REDIS_URI}` |
+| Mongoose | `MONGODB_URI` | `${MONGODB.MONGO_CONNECTION_STRING}` |
+
+> **Cross-service variable references** (e.g., `${POSTGRESQL.POSTGRES_CONNECTION_STRING}`) should be set via the Zeabur Dashboard or GraphQL API — the CLI has a known issue with `${}` expansion. See the `zeabur-variables` skill for details.
+
+## Step 5 — Verify
+
+1. Check that the database service is running:
+   ```bash
+   npx zeabur@latest deployment log --service-id <database-service-id>
+   ```
+
+2. Test connectivity from the application container:
+   ```bash
+   # PostgreSQL
+   npx zeabur@latest service exec --id <app-service-id> -- nc -z postgresql.zeabur.internal 5432
+
+   # MySQL
+   npx zeabur@latest service exec --id <app-service-id> -- nc -z mysql.zeabur.internal 3306
+
+   # MongoDB
+   npx zeabur@latest service exec --id <app-service-id> -- nc -z mongodb.zeabur.internal 27017
+
+   # Redis
+   npx zeabur@latest service exec --id <app-service-id> -- nc -z redis.zeabur.internal 6379
+   ```
+
+3. If the app fails to connect, check the `zeabur-startup-order` skill — the database may not be ready when the app starts.
+
+## Tips
+
+- **Change the default database name:** Edit the `POSTGRES_DB` / `MYSQL_DATABASE` / `MONGO_INITDB_DATABASE` value in the template before deploying.
+- **External access:** Databases use TCP ports. Port forwarding is auto-enabled. Get the external host:port with `npx zeabur@latest service network --id <service-id>`.
+- **Data persistence:** All templates include volumes. Data survives restarts and redeployments.
+- **Run queries:** Use the `zeabur-service-exec` skill to run database clients inside the container:
+  ```bash
+  # PostgreSQL
+  npx zeabur@latest service exec --id <db-service-id> -- psql -U postgres -d mydb
+
+  # MySQL
+  npx zeabur@latest service exec --id <db-service-id> -- mysql -u root -p
+
+  # MongoDB
+  npx zeabur@latest service exec --id <db-service-id> -- mongosh -u root -p
+
+  # Redis
+  npx zeabur@latest service exec --id <db-service-id> -- redis-cli
+  ```

--- a/skills/zeabur-database/SKILL.md
+++ b/skills/zeabur-database/SKILL.md
@@ -22,7 +22,7 @@ npx zeabur@latest template get -c <TEMPLATE_CODE> --raw
 npx zeabur@latest template deploy -c <TEMPLATE_CODE> -i=false --project-id <project-id>
 ```
 
-Pick the template with the highest deployment count. If the user doesn't specify a database, **ask** rather than guessing.
+Pick the template with the highest deployment count. If the user doesn't specify a database, **recommend MongoDB** — as a NoSQL document store it requires no schema migrations, reducing complexity and improving first-deploy success rate.
 
 > For creating a custom database template from scratch, use the `zeabur-template` skill.
 

--- a/skills/zeabur-database/SKILL.md
+++ b/skills/zeabur-database/SKILL.md
@@ -105,15 +105,29 @@ ${POSTGRESQL.POSTGRES_CONNECTION_STRING}
 
 ---
 
-## Local Connection (Port Forwarding)
+## External Connection (from local machine)
 
-Database ports are TCP with port forwarding auto-enabled. To get the external host:port for local tools:
+Database ports are TCP. Use `service instruction` to get the **resolved** external connection info (hostname, port, connection string with real values already substituted):
 
 ```bash
-npx zeabur@latest service network --id <database-service-id>
+npx zeabur@latest service instruction --id <database-service-id> -i=false
 ```
 
-This returns `PORT_FORWARDED_HOSTNAME` and the forwarded port. Use them to connect from local tools:
+This outputs ready-to-use values like:
+```
+Connection String: postgresql://root:abc123@xxx.clusters.zeabur.com:12345/zeabur
+PostgreSQL Connect Command: psql "postgresql://root:abc123@xxx.clusters.zeabur.com:12345/zeabur"
+PostgreSQL host: xxx.clusters.zeabur.com
+PostgreSQL port: 12345
+```
+
+Alternatively, use `service network` to get the raw port-forwarding details (only works for TCP/UDP ports):
+
+```bash
+npx zeabur@latest service network --id <database-service-id> --json -i=false
+```
+
+This returns `portForwardedHost` and each port's `forwardedPort`. Use them to connect from local tools:
 
 ```bash
 # PostgreSQL (psql)
@@ -129,7 +143,7 @@ mongosh "mongodb://mongo:PASSWORD@FORWARDED_HOST:FORWARDED_PORT"
 redis-cli -h FORWARDED_HOST -p FORWARDED_PORT -a PASSWORD
 ```
 
-You can also connect from GUI tools (DBeaver, TablePlus, pgAdmin, MongoDB Compass, RedisInsight, etc.) using the same forwarded host:port.
+You can also connect from GUI tools (DBeaver, TablePlus, pgAdmin, MongoDB Compass, RedisInsight, etc.) using the same host:port.
 
 ---
 

--- a/skills/zeabur-database/SKILL.md
+++ b/skills/zeabur-database/SKILL.md
@@ -9,22 +9,15 @@ description: Use when deploying a database to Zeabur. Use when user needs MySQL,
 
 ## Deploy a Database
 
-Search and deploy a database template:
+> **Before deploying, you MUST load the `zeabur-template` skill first** to understand what Zeabur templates are, how they work, and how to deploy them. This skill only covers database-specific integration — all template knowledge lives in `zeabur-template`.
+
+Search for a database template:
 
 ```bash
-# Search for a database template (postgresql, mysql, mongodb, redis)
 npx zeabur@latest template search postgresql -i=false --json
-
-# Inspect a template's full definition (env vars, volumes, ports)
-npx zeabur@latest template get -c <TEMPLATE_CODE> --raw
-
-# Deploy to the user's project
-npx zeabur@latest template deploy -c <TEMPLATE_CODE> -i=false --project-id <project-id>
 ```
 
 Pick the template with the highest deployment count. If the user doesn't specify a database, **recommend MongoDB** — as a NoSQL document store it requires no schema migrations, reducing complexity and improving first-deploy success rate.
-
-> For creating a custom database template from scratch, use the `zeabur-template` skill.
 
 ---
 

--- a/skills/zeabur-database/SKILL.md
+++ b/skills/zeabur-database/SKILL.md
@@ -7,20 +7,38 @@ description: Use when deploying a database to Zeabur. Use when user needs MySQL,
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
 
-Deploy a database (PostgreSQL, MySQL, MongoDB, or Redis) to the user's Zeabur project via a template YAML, then help them integrate it with their application.
+Deploy a database (PostgreSQL, MySQL, MongoDB, or Redis) to the user's Zeabur project via an existing template, then help them integrate it with their application.
 
 ## Step 1 — Identify What the User Needs
 
-| User Need | Database | Default Image |
-|-----------|----------|---------------|
-| Relational DB, SQL, ORM | PostgreSQL | `postgres:16-alpine` |
-| MySQL-compatible, WordPress, legacy apps | MySQL (MariaDB) | `mariadb:10.6` |
-| Document store, JSON, NoSQL | MongoDB | `mongo:8.0` |
-| Cache, session store, queue, pub/sub | Redis | `redis:7-alpine` |
+| User Need | Search Keyword |
+|-----------|---------------|
+| Relational DB, SQL, ORM | `postgresql` |
+| MySQL-compatible, WordPress, legacy apps | `mysql` |
+| Document store, JSON, NoSQL | `mongodb` |
+| Cache, session store, queue, pub/sub | `redis` |
 
 If the user doesn't specify, **ask which database they need** rather than guessing.
 
-## Step 2 — Identify the Target Project
+## Step 2 — Find the Template
+
+Search for existing database templates on Zeabur:
+
+```bash
+npx zeabur@latest template search postgresql -i=false --json
+```
+
+This returns a JSON array of matching templates. Pick the one with the highest deployment count (more battle-tested). Note the `code` field — you'll need it to deploy.
+
+To inspect a template's full YAML (service definitions, env vars, volumes, etc.):
+
+```bash
+npx zeabur@latest template get -c <TEMPLATE_CODE> --raw
+```
+
+> For advanced customization or creating a template from scratch, use the `zeabur-template` skill.
+
+## Step 3 — Identify the Target Project
 
 The database must be deployed into a project. Use the `zeabur-service-list` skill or ask the user for their project ID.
 
@@ -28,212 +46,15 @@ The database must be deployed into a project. Use the `zeabur-service-list` skil
 npx zeabur@latest service list --project-id <project-id>
 ```
 
-## Step 3 — Write and Deploy the Template
+## Step 4 — Deploy the Template
 
-Create a template YAML file and deploy it to the user's project. Pick the matching template below, save it to a `.yaml` file, then deploy:
+Deploy the database template into the user's project:
 
 ```bash
-npx zeabur@latest template deploy -f database.yaml -i=false --project-id <project-id>
+npx zeabur@latest template deploy -c <TEMPLATE_CODE> -i=false --project-id <project-id>
 ```
 
-### PostgreSQL
-
-```yaml
-# yaml-language-server: $schema=https://schema.zeabur.app/template.json
-apiVersion: zeabur.com/v1
-kind: Template
-metadata:
-  name: PostgreSQL
-spec:
-  description: PostgreSQL relational database
-  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/postgresql.svg
-  tags:
-    - Database
-  variables: []
-  readme: ""
-  services:
-    - name: postgresql
-      icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/postgresql.svg
-      template: PREBUILT_V2
-      spec:
-        source:
-          image: postgres:16-alpine
-        ports:
-          - id: database
-            port: 5432
-            type: TCP
-        volumes:
-          - id: data
-            dir: /var/lib/postgresql/data
-        env:
-          POSTGRES_USER:
-            default: postgres
-            expose: true
-          POSTGRES_PASSWORD:
-            default: ${PASSWORD}
-            expose: true
-          POSTGRES_DB:
-            default: mydb
-            expose: true
-          POSTGRES_HOST:
-            default: ${CONTAINER_HOSTNAME}
-            expose: true
-            readonly: true
-          POSTGRES_PORT:
-            default: ${DATABASE_PORT}
-            expose: true
-            readonly: true
-          POSTGRES_CONNECTION_STRING:
-            default: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
-            expose: true
-            readonly: true
-```
-
-### MySQL (MariaDB)
-
-```yaml
-# yaml-language-server: $schema=https://schema.zeabur.app/template.json
-apiVersion: zeabur.com/v1
-kind: Template
-metadata:
-  name: MySQL
-spec:
-  description: MySQL-compatible database (MariaDB)
-  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/mariadb.svg
-  tags:
-    - Database
-  variables: []
-  readme: ""
-  services:
-    - name: mysql
-      icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/mariadb.svg
-      template: PREBUILT_V2
-      spec:
-        source:
-          image: mariadb:10.6
-        ports:
-          - id: database
-            port: 3306
-            type: TCP
-        volumes:
-          - id: data
-            dir: /var/lib/mysql
-        env:
-          MYSQL_ROOT_PASSWORD:
-            default: ${PASSWORD}
-            expose: true
-          MYSQL_DATABASE:
-            default: mydb
-            expose: true
-          MYSQL_HOST:
-            default: ${CONTAINER_HOSTNAME}
-            expose: true
-            readonly: true
-          MYSQL_PORT:
-            default: ${DATABASE_PORT}
-            expose: true
-            readonly: true
-          MYSQL_CONNECTION_STRING:
-            default: mysql://root:${MYSQL_ROOT_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}
-            expose: true
-            readonly: true
-```
-
-### MongoDB
-
-```yaml
-# yaml-language-server: $schema=https://schema.zeabur.app/template.json
-apiVersion: zeabur.com/v1
-kind: Template
-metadata:
-  name: MongoDB
-spec:
-  description: MongoDB document database
-  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/mongodb.svg
-  tags:
-    - Database
-  variables: []
-  readme: ""
-  services:
-    - name: mongodb
-      icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/mongodb.svg
-      template: PREBUILT_V2
-      spec:
-        source:
-          image: mongo:8.0
-        ports:
-          - id: database
-            port: 27017
-            type: TCP
-        volumes:
-          - id: data
-            dir: /data/db
-        env:
-          MONGO_INITDB_ROOT_USERNAME:
-            default: root
-            expose: true
-          MONGO_INITDB_ROOT_PASSWORD:
-            default: ${PASSWORD}
-            expose: true
-          MONGO_HOST:
-            default: ${CONTAINER_HOSTNAME}
-            expose: true
-            readonly: true
-          MONGO_PORT:
-            default: ${DATABASE_PORT}
-            expose: true
-            readonly: true
-          MONGO_CONNECTION_STRING:
-            default: mongodb://${MONGO_INITDB_ROOT_USERNAME}:${MONGO_INITDB_ROOT_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}
-            expose: true
-            readonly: true
-```
-
-### Redis
-
-```yaml
-# yaml-language-server: $schema=https://schema.zeabur.app/template.json
-apiVersion: zeabur.com/v1
-kind: Template
-metadata:
-  name: Redis
-spec:
-  description: Redis in-memory data store
-  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/redis.svg
-  tags:
-    - Database
-  variables: []
-  readme: ""
-  services:
-    - name: redis
-      icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/redis.svg
-      template: PREBUILT_V2
-      spec:
-        source:
-          image: redis:7-alpine
-        ports:
-          - id: database
-            port: 6379
-            type: TCP
-        volumes:
-          - id: data
-            dir: /data
-        env:
-          REDIS_HOST:
-            default: ${CONTAINER_HOSTNAME}
-            expose: true
-            readonly: true
-          REDIS_PORT:
-            default: ${DATABASE_PORT}
-            expose: true
-            readonly: true
-          REDIS_URI:
-            default: redis://${REDIS_HOST}:${REDIS_PORT}
-            expose: true
-            readonly: true
-```
-
-## Step 4 — Integrate with Application
+## Step 5 — Integrate with Application
 
 After deploying, the database exposes connection variables that other services can reference. Use the `zeabur-variables` skill to set env vars on the application service.
 
@@ -245,6 +66,8 @@ After deploying, the database exposes connection variables that other services c
 | MySQL | `MYSQL_CONNECTION_STRING` | `mysql://root:xxx@mysql.zeabur.internal:3306/mydb` |
 | MongoDB | `MONGO_CONNECTION_STRING` | `mongodb://root:xxx@mongodb.zeabur.internal:27017` |
 | Redis | `REDIS_URI` | `redis://redis.zeabur.internal:6379` |
+
+> **Note:** The actual variable names depend on the template. Use `npx zeabur@latest template get -c <TEMPLATE_CODE> --raw` to check the exact env var names exposed by the template.
 
 ### Common Application Env Var Names
 
@@ -263,7 +86,7 @@ Map the database connection string to whatever env var your app framework expect
 
 > **Cross-service variable references** (e.g., `${POSTGRESQL.POSTGRES_CONNECTION_STRING}`) should be set via the Zeabur Dashboard or GraphQL API — the CLI has a known issue with `${}` expansion. See the `zeabur-variables` skill for details.
 
-## Step 5 — Verify
+## Step 6 — Verify
 
 1. Check that the database service is running:
    ```bash
@@ -289,9 +112,8 @@ Map the database connection string to whatever env var your app framework expect
 
 ## Tips
 
-- **Change the default database name:** Edit the `POSTGRES_DB` / `MYSQL_DATABASE` / `MONGO_INITDB_DATABASE` value in the template before deploying.
 - **External access:** Databases use TCP ports. Port forwarding is auto-enabled. Get the external host:port with `npx zeabur@latest service network --id <service-id>`.
-- **Data persistence:** All templates include volumes. Data survives restarts and redeployments.
+- **Data persistence:** Database templates include volumes. Data survives restarts and redeployments.
 - **Run queries:** Use the `zeabur-service-exec` skill to run database clients inside the container:
   ```bash
   # PostgreSQL

--- a/skills/zeabur-database/SKILL.md
+++ b/skills/zeabur-database/SKILL.md
@@ -41,7 +41,7 @@ This shows:
 npx zeabur@latest variable list --id <database-service-id> -i=false
 ```
 
-This lists all the credentials (username, password, database name, connection string, etc.) for the database service.
+This lists all the credentials (username, password, database name, etc.) for the database service.
 
 ---
 
@@ -54,7 +54,6 @@ This lists all the credentials (username, password, database name, connection st
 | `POSTGRES_USERNAME` | Username (default: `root`) |
 | `POSTGRES_PASSWORD` | Password (auto-generated) |
 | `POSTGRES_DATABASE` | Database name (default: `zeabur`) |
-| `POSTGRES_CONNECTION_STRING` | Full connection string |
 
 ### Connect from local machine
 
@@ -64,15 +63,7 @@ psql "postgresql://POSTGRES_USERNAME:POSTGRES_PASSWORD@PUBLIC_HOST:PUBLIC_PORT/P
 
 ### Connect from app (same project)
 
-Set `DATABASE_URL` on your app service to reference the exposed variable:
-
-```
-${POSTGRES_CONNECTION_STRING}
-```
-
-Works with Django, Rails, Prisma, Next.js, and any framework that reads `DATABASE_URL`.
-
-For frameworks that need individual vars (e.g., Laravel, Spring Boot):
+Set env vars on your app service using the values from `variable list`:
 
 ```
 DB_HOST=${POSTGRES_HOST}
@@ -81,6 +72,8 @@ DB_USERNAME=${POSTGRES_USERNAME}
 DB_PASSWORD=${POSTGRES_PASSWORD}
 DB_DATABASE=${POSTGRES_DATABASE}
 ```
+
+Or construct a connection string: `postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}`
 
 ---
 
@@ -94,8 +87,6 @@ DB_DATABASE=${POSTGRES_DATABASE}
 | `MYSQL_PASSWORD` | Password (auto-generated) |
 | `MYSQL_DATABASE` | Database name (default: `zeabur`) |
 
-> The official MySQL template does not expose a connection string variable.
-
 ### Connect from local machine
 
 ```bash
@@ -104,13 +95,7 @@ mysql -h PUBLIC_HOST -P PUBLIC_PORT -u MYSQL_USERNAME -p MYSQL_DATABASE
 
 ### Connect from app (same project)
 
-Construct the connection string manually in your app's env var:
-
-```
-DATABASE_URL=mysql://root:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}
-```
-
-Or use individual vars:
+Set env vars on your app service using the values from `variable list`:
 
 ```
 DB_HOST=${MYSQL_HOST}
@@ -119,6 +104,8 @@ DB_USERNAME=${MYSQL_USERNAME}
 DB_PASSWORD=${MYSQL_PASSWORD}
 DB_DATABASE=${MYSQL_DATABASE}
 ```
+
+Or construct a connection string: `mysql://${MYSQL_USERNAME}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}`
 
 ---
 
@@ -130,7 +117,6 @@ DB_DATABASE=${MYSQL_DATABASE}
 |----------|-------------|
 | `MONGO_USERNAME` | Username (default: `mongo`) |
 | `MONGO_PASSWORD` | Password (auto-generated) |
-| `MONGO_CONNECTION_STRING` | Full connection string |
 
 ### Connect from local machine
 
@@ -140,11 +126,7 @@ mongosh "mongodb://MONGO_USERNAME:MONGO_PASSWORD@PUBLIC_HOST:PUBLIC_PORT"
 
 ### Connect from app (same project)
 
-Set `MONGODB_URI` on your app service:
-
-```
-${MONGO_CONNECTION_STRING}
-```
+Construct a connection string: `mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}`
 
 Works with Mongoose, PyMongo, and any MongoDB driver.
 
@@ -157,7 +139,6 @@ Works with Mongoose, PyMongo, and any MongoDB driver.
 | Variable | Description |
 |----------|-------------|
 | `REDIS_PASSWORD` | Password (auto-generated) |
-| `REDIS_CONNECTION_STRING` | Full connection string |
 
 > Redis has no username or database name by default.
 
@@ -169,11 +150,7 @@ redis-cli -h PUBLIC_HOST -p PUBLIC_PORT -a REDIS_PASSWORD
 
 ### Connect from app (same project)
 
-Set `REDIS_URL` on your app service:
-
-```
-${REDIS_CONNECTION_STRING}
-```
+Construct a connection string: `redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}`
 
 Works with ioredis, redis-py, go-redis, and any Redis client.
 

--- a/skills/zeabur-object-storage/SKILL.md
+++ b/skills/zeabur-object-storage/SKILL.md
@@ -7,19 +7,37 @@ description: Use when deploying object storage (S3-compatible) to Zeabur. Use wh
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
 
-Deploy an S3-compatible object storage service (MinIO or RustFS) to the user's Zeabur project, then help them integrate it with their application.
+Deploy an S3-compatible object storage service (MinIO or RustFS) to the user's Zeabur project via an existing template, then help them integrate it with their application.
 
 ## Step 1 — Choose the Right Storage
 
-| User Need | Service | Image | Notes |
-|-----------|---------|-------|-------|
-| Full-featured S3, web console, IAM, versioning | MinIO | `minio/minio:RELEASE.2025-02-28T09-55-16Z` | Feature-rich, higher memory (~512MB+) |
-| Lightweight S3-compatible storage | RustFS | `rustfs/rustfs:0.1.1` | Minimal footprint, fast, S3-compatible |
+| User Need | Search Keyword | Notes |
+|-----------|---------------|-------|
+| Full-featured S3, web console, IAM, versioning | `minio` | Feature-rich, higher memory (~512MB+) |
+| Lightweight S3-compatible storage | `rustfs` | Minimal footprint, fast, S3-compatible |
 
 - **Default to MinIO** if the user doesn't specify — it's the most widely supported and has a built-in web console.
 - **Recommend RustFS** if the user wants lightweight/minimal or mentions RustFS specifically.
 
-## Step 2 — Identify the Target Project
+## Step 2 — Find the Template
+
+Search for existing object storage templates on Zeabur:
+
+```bash
+npx zeabur@latest template search minio -i=false --json
+```
+
+This returns a JSON array of matching templates. Pick the one with the highest deployment count (more battle-tested). Note the `code` field — you'll need it to deploy.
+
+To inspect a template's full YAML (service definitions, env vars, volumes, etc.):
+
+```bash
+npx zeabur@latest template get -c <TEMPLATE_CODE> --raw
+```
+
+> For advanced customization or creating a template from scratch, use the `zeabur-template` skill.
+
+## Step 3 — Identify the Target Project
 
 The storage service must be deployed into a project. Use the `zeabur-service-list` skill or ask the user for their project ID.
 
@@ -27,151 +45,15 @@ The storage service must be deployed into a project. Use the `zeabur-service-lis
 npx zeabur@latest service list --project-id <project-id>
 ```
 
-## Step 3 — Write and Deploy the Template
+## Step 4 — Deploy the Template
 
-Create a template YAML file and deploy it to the user's project:
+Deploy the storage template into the user's project:
 
 ```bash
-npx zeabur@latest template deploy -f object-storage.yaml -i=false --project-id <project-id>
+npx zeabur@latest template deploy -c <TEMPLATE_CODE> -i=false --project-id <project-id>
 ```
 
-### MinIO
-
-```yaml
-# yaml-language-server: $schema=https://schema.zeabur.app/template.json
-apiVersion: zeabur.com/v1
-kind: Template
-metadata:
-  name: MinIO
-spec:
-  description: S3-compatible object storage with web console
-  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/minio.svg
-  tags:
-    - Storage
-  variables:
-    - key: CONSOLE_DOMAIN
-      type: DOMAIN
-      name: MinIO Console Domain
-      description: Domain for the MinIO web console
-  readme: ""
-  services:
-    - name: minio
-      icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/minio.svg
-      template: PREBUILT_V2
-      domainKey:
-        - port: console
-          variable: CONSOLE_DOMAIN
-      spec:
-        source:
-          image: minio/minio:RELEASE.2025-02-28T09-55-16Z
-          command:
-            - minio
-            - server
-            - /data
-            - --console-address
-            - ":9001"
-        ports:
-          - id: api
-            port: 9000
-            type: TCP
-          - id: console
-            port: 9001
-            type: HTTP
-        portForwarding:
-          enabled: true
-        volumes:
-          - id: data
-            dir: /data
-        env:
-          MINIO_ROOT_USER:
-            default: minioadmin
-            expose: true
-          MINIO_ROOT_PASSWORD:
-            default: ${PASSWORD}
-            expose: true
-          MINIO_HOST:
-            default: ${CONTAINER_HOSTNAME}
-            expose: true
-            readonly: true
-          MINIO_PORT:
-            default: ${API_PORT}
-            expose: true
-            readonly: true
-          MINIO_ENDPOINT:
-            default: http://${MINIO_HOST}:${MINIO_PORT}
-            expose: true
-            readonly: true
-```
-
-### RustFS
-
-```yaml
-# yaml-language-server: $schema=https://schema.zeabur.app/template.json
-apiVersion: zeabur.com/v1
-kind: Template
-metadata:
-  name: RustFS
-spec:
-  description: Lightweight S3-compatible object storage
-  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/rustfs.svg
-  tags:
-    - Storage
-  variables:
-    - key: CONSOLE_DOMAIN
-      type: DOMAIN
-      name: RustFS Console Domain
-      description: Domain for the RustFS web console
-  readme: ""
-  services:
-    - name: rustfs
-      icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/rustfs.svg
-      template: PREBUILT_V2
-      domainKey:
-        - port: console
-          variable: CONSOLE_DOMAIN
-      spec:
-        source:
-          image: rustfs/rustfs:0.1.1
-          command:
-            - rustfs
-            - server
-            - /data
-            - --console-address
-            - ":9001"
-        ports:
-          - id: api
-            port: 9000
-            type: TCP
-          - id: console
-            port: 9001
-            type: HTTP
-        portForwarding:
-          enabled: true
-        volumes:
-          - id: data
-            dir: /data
-        env:
-          RUSTFS_ROOT_USER:
-            default: minioadmin
-            expose: true
-          RUSTFS_ROOT_PASSWORD:
-            default: ${PASSWORD}
-            expose: true
-          RUSTFS_HOST:
-            default: ${CONTAINER_HOSTNAME}
-            expose: true
-            readonly: true
-          RUSTFS_PORT:
-            default: ${API_PORT}
-            expose: true
-            readonly: true
-          RUSTFS_ENDPOINT:
-            default: http://${RUSTFS_HOST}:${RUSTFS_PORT}
-            expose: true
-            readonly: true
-```
-
-## Step 4 — Access the Web Console
+## Step 5 — Access the Web Console
 
 Both MinIO and RustFS provide a web console for managing buckets and files.
 
@@ -180,45 +62,34 @@ Both MinIO and RustFS provide a web console for managing buckets and files.
    npx zeabur@latest service list --project-id <project-id>
    ```
 
-2. Open the console URL in a browser and log in with the root credentials:
-   - **MinIO:** user `minioadmin`, password from `MINIO_ROOT_PASSWORD`
-   - **RustFS:** user `minioadmin`, password from `RUSTFS_ROOT_PASSWORD`
+2. Open the console URL in a browser and log in with the root credentials (check the template's env vars for the username and password).
 
 3. Create a bucket in the console before your application can upload files.
 
-## Step 5 — Integrate with Application
+## Step 6 — Integrate with Application
 
 After deploying, set S3-compatible env vars on the application service. Use the `zeabur-variables` skill.
 
-### Connection Variables
-
-| Service | Variable | Example Value |
-|---------|----------|---------------|
-| MinIO | `MINIO_ENDPOINT` | `http://minio.zeabur.internal:9000` |
-| MinIO | `MINIO_ROOT_USER` | `minioadmin` |
-| MinIO | `MINIO_ROOT_PASSWORD` | (auto-generated) |
-| RustFS | `RUSTFS_ENDPOINT` | `http://rustfs.zeabur.internal:9000` |
-| RustFS | `RUSTFS_ROOT_USER` | `minioadmin` |
-| RustFS | `RUSTFS_ROOT_PASSWORD` | (auto-generated) |
+> **Note:** The actual variable names depend on the template. Use `npx zeabur@latest template get -c <TEMPLATE_CODE> --raw` to check the exact env var names exposed by the template.
 
 ### Common Application Env Var Mapping
 
 Most apps and SDKs use the standard AWS S3 env var names. Map them to the storage service variables:
 
-| App Env Var | Value (MinIO) | Value (RustFS) |
-|-------------|---------------|----------------|
-| `S3_ENDPOINT` or `AWS_ENDPOINT_URL` | `${MINIO.MINIO_ENDPOINT}` | `${RUSTFS.RUSTFS_ENDPOINT}` |
-| `S3_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` | `${MINIO.MINIO_ROOT_USER}` | `${RUSTFS.RUSTFS_ROOT_USER}` |
-| `S3_SECRET_KEY` or `AWS_SECRET_ACCESS_KEY` | `${MINIO.MINIO_ROOT_PASSWORD}` | `${RUSTFS.RUSTFS_ROOT_PASSWORD}` |
-| `S3_BUCKET` | (bucket name created in console) | (bucket name created in console) |
-| `S3_REGION` | `us-east-1` (default, any value works) | `us-east-1` |
-| `S3_FORCE_PATH_STYLE` | `true` | `true` |
+| App Env Var | Description |
+|-------------|-------------|
+| `S3_ENDPOINT` or `AWS_ENDPOINT_URL` | The storage service's internal endpoint (e.g., `http://minio.zeabur.internal:9000`) |
+| `S3_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` | Root user from the storage service |
+| `S3_SECRET_KEY` or `AWS_SECRET_ACCESS_KEY` | Root password from the storage service |
+| `S3_BUCKET` | Bucket name created in the console |
+| `S3_REGION` | `us-east-1` (default, any value works) |
+| `S3_FORCE_PATH_STYLE` | `true` |
 
 > **Important:** `S3_FORCE_PATH_STYLE=true` (or `forcePathStyle: true` in SDK config) is required for MinIO/RustFS. Without it, the SDK will try virtual-hosted-style URLs which won't resolve.
 
 > **Cross-service variable references** (e.g., `${MINIO.MINIO_ENDPOINT}`) should be set via the Zeabur Dashboard or GraphQL API — the CLI has a known issue with `${}` expansion. See the `zeabur-variables` skill for details.
 
-## Step 6 — Verify
+## Step 7 — Verify
 
 1. Check that the storage service is running:
    ```bash
@@ -227,14 +98,10 @@ Most apps and SDKs use the standard AWS S3 env var names. Map them to the storag
 
 2. Test S3 API connectivity from the application container:
    ```bash
-   # MinIO
    npx zeabur@latest service exec --id <app-service-id> -- nc -z minio.zeabur.internal 9000
-
-   # RustFS
-   npx zeabur@latest service exec --id <app-service-id> -- nc -z rustfs.zeabur.internal 9000
    ```
 
-3. Test with a simple S3 operation (if `curl` is available in the app container):
+3. Test with a simple health check (if `curl` is available in the app container):
    ```bash
    npx zeabur@latest service exec --id <app-service-id> -- \
      curl -s -o /dev/null -w "%{http_code}" http://minio.zeabur.internal:9000/minio/health/live
@@ -243,13 +110,7 @@ Most apps and SDKs use the standard AWS S3 env var names. Map them to the storag
 ## Tips
 
 - **External API access:** The S3 API port uses TCP with port forwarding enabled. Get the external endpoint with `npx zeabur@latest service network --id <service-id>`.
-- **Data persistence:** Both templates include volumes. Uploaded files survive restarts.
-- **Bucket creation via CLI:** If `mc` (MinIO Client) is available:
-  ```bash
-  npx zeabur@latest service exec --id <storage-service-id> -- \
-    mc alias set local http://localhost:9000 minioadmin PASSWORD && \
-    mc mb local/my-bucket
-  ```
+- **Data persistence:** Storage templates include volumes. Uploaded files survive restarts.
 - **SDK examples** — Most S3 SDKs just need endpoint + credentials + `forcePathStyle`:
   ```javascript
   // Node.js (AWS SDK v3)

--- a/skills/zeabur-object-storage/SKILL.md
+++ b/skills/zeabur-object-storage/SKILL.md
@@ -24,83 +24,129 @@ Pick the template with the highest deployment count.
 
 ---
 
-## Retrieve Connection Parameters
+## After Deployment: How to Connect
 
-After deploying, list the storage service's variables:
+For object storage, you need: **S3 API endpoint** (how to connect), **access key + secret key** (how to authenticate), and a **bucket name**.
+
+### How to connect — `service network`
+
+```bash
+npx zeabur@latest service network --id <storage-service-id> -i=false
+```
+
+This shows:
+- **Private Networking** — internal `hostname:port` for the S3 API (e.g., `minio.zeabur.internal:9000`)
+- **Public Networking** — for HTTP ports, it will indicate you need to bind a domain to access externally
+
+> MinIO and RustFS ports are **HTTP type**, so public access is via **domain binding**, not port forwarding. Bind a domain to the API port via the Dashboard to get an external S3 endpoint (e.g., `https://minio-api.zeabur.app`).
+
+### How to authenticate — `variable list`
 
 ```bash
 npx zeabur@latest variable list --id <storage-service-id> -i=false
 ```
 
-Exposed variables from the official Zeabur templates:
+This lists the access key, secret key, and other credentials.
 
-### MinIO (template code: `TLJ3RL`)
+---
+
+## MinIO
+
+### Credentials (from `variable list`)
 
 | Variable | Description |
 |----------|-------------|
 | `MINIO_USERNAME` | Access Key ID (default: `minio`) |
 | `MINIO_PASSWORD` | Secret Access Key (auto-generated) |
-| `MINIO_CONSOLE_URL` | Full URL for the web console |
 | `MINIO_DEFAULT_BUCKET` | Default bucket name (default: `zeabur`) |
+| `MINIO_CONSOLE_URL` | Web console URL |
 
-The MinIO template exposes two HTTP ports:
-- **API** (port `9000`) — S3-compatible API, accessed internally as `http://minio.zeabur.internal:9000`
-- **Console** (port `9090`) — Web management UI, accessed via the domain in `MINIO_CONSOLE_URL`
+### Connect from app (same project)
 
-> **Note:** The MinIO template does **not** expose `MINIO_HOST`, `MINIO_PORT`, or `MINIO_ENDPOINT` variables. The internal S3 endpoint must be constructed manually: `http://minio.zeabur.internal:9000` (where `minio` is the service name).
+Set these env vars on your app service:
 
-### RustFS (template code: `7FG0WI`)
+```
+S3_ENDPOINT=http://minio.zeabur.internal:9000
+S3_ACCESS_KEY=${MINIO_USERNAME}
+S3_SECRET_KEY=${MINIO_PASSWORD}
+S3_BUCKET=zeabur
+S3_REGION=us-east-1
+S3_FORCE_PATH_STYLE=true
+```
+
+> The S3 endpoint is not exposed as a variable — you must hardcode it using the internal hostname from `service network`.
+
+### Connect from local machine
+
+Bind a domain to the API port, then use that domain as endpoint:
+
+```bash
+# MinIO Client (mc)
+mc alias set zeabur https://MINIO_API_DOMAIN MINIO_USERNAME MINIO_PASSWORD
+mc ls zeabur/
+mc cp local-file.txt zeabur/zeabur/
+
+# AWS CLI
+aws --endpoint-url https://MINIO_API_DOMAIN s3 ls
+```
+
+### Web Console
+
+Open `MINIO_CONSOLE_URL` in a browser, login with `MINIO_USERNAME` / `MINIO_PASSWORD`. MinIO auto-creates a `zeabur` bucket on first boot.
+
+---
+
+## RustFS
+
+### Credentials (from `variable list`)
 
 | Variable | Description |
 |----------|-------------|
 | `RUSTFS_USERNAME` | Access Key ID (default: `rustfs`) |
 | `RUSTFS_PASSWORD` | Secret Access Key (auto-generated) |
 
-The RustFS template exposes two HTTP ports:
-- **API** (port `9000`) — S3-compatible API, accessed internally as `http://rustfs.zeabur.internal:9000`
-- **Console** (port `9001`) — Web management UI
+### Connect from app (same project)
 
-> **Note:** The RustFS template does **not** expose HOST/PORT/ENDPOINT variables. Construct the internal endpoint manually: `http://rustfs.zeabur.internal:9000` (where `rustfs` or `RustFS` is the service name — check `service list` for the exact name).
+Set these env vars on your app service:
 
-> **Variable names may differ across templates.** Always run `variable list` to confirm the actual keys.
+```
+S3_ENDPOINT=http://rustfs.zeabur.internal:9000
+S3_ACCESS_KEY=${RUSTFS_USERNAME}
+S3_SECRET_KEY=${RUSTFS_PASSWORD}
+S3_BUCKET=my-bucket
+S3_REGION=us-east-1
+S3_FORCE_PATH_STYLE=true
+```
+
+> The S3 endpoint is not exposed as a variable — you must hardcode it using the internal hostname from `service network`. Also check `service list` for the exact service name (may be `RustFS` not `rustfs`).
+
+> **You must create a bucket first** — unlike MinIO, RustFS starts with zero buckets.
+
+### Connect from local machine
+
+Bind a domain to the API port, then:
+
+```bash
+mc alias set zeabur https://RUSTFS_API_DOMAIN RUSTFS_USERNAME RUSTFS_PASSWORD
+mc mb zeabur/my-bucket
+mc ls zeabur/
+```
+
+### Web Console
+
+Open the domain bound to port `9001` in a browser, login with `RUSTFS_USERNAME` / `RUSTFS_PASSWORD`. Create a bucket before your app can upload files.
 
 ---
 
-## Integrate with Application
+## SDK Examples
 
-### Cross-service variable references
-
-Zeabur uses a **flat variable namespace** — all exposed variables from every service in the same project are merged together. Your app can reference them directly by name, no service prefix needed:
-
-```
-${MINIO_USERNAME}
-${MINIO_PASSWORD}
-```
-
-> **CLI limitation:** The CLI has a known bug with `${}` expansion — variable references should be set via the **Zeabur Dashboard**. See the `zeabur-variables` skill for details.
-
-### S3 SDK env var mapping
-
-Most S3-compatible SDKs need these values:
-
-| App Env Var | MinIO Value | RustFS Value |
-|-------------|-------------|--------------|
-| `S3_ENDPOINT` or `AWS_ENDPOINT_URL` | `http://minio.zeabur.internal:9000` | `http://rustfs.zeabur.internal:9000` |
-| `S3_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` | `${MINIO_USERNAME}` | `${RUSTFS_USERNAME}` |
-| `S3_SECRET_KEY` or `AWS_SECRET_ACCESS_KEY` | `${MINIO_PASSWORD}` | `${RUSTFS_PASSWORD}` |
-| `S3_BUCKET` | `zeabur` (MinIO auto-creates this) | (must create bucket first) |
-| `S3_REGION` | `us-east-1` (any value works, but must be set) | `us-east-1` |
-| `S3_FORCE_PATH_STYLE` | `true` | `true` |
-
-> **Important:** The S3 endpoint must be hardcoded or set manually because the templates don't expose it as a variable. Use the internal hostname `<service-name>.zeabur.internal:9000`.
-
-### SDK code examples
+All S3-compatible SDKs need: endpoint, access key, secret key, region, and `forcePathStyle: true`.
 
 ```javascript
 // Node.js (AWS SDK v3)
 const { S3Client } = require("@aws-sdk/client-s3");
 const s3 = new S3Client({
-  endpoint: process.env.S3_ENDPOINT, // http://minio.zeabur.internal:9000
+  endpoint: process.env.S3_ENDPOINT,
   credentials: {
     accessKeyId: process.env.S3_ACCESS_KEY,
     secretAccessKey: process.env.S3_SECRET_KEY,
@@ -112,15 +158,14 @@ const s3 = new S3Client({
 
 ```python
 # Python (boto3)
-import boto3
+import boto3, os
 s3 = boto3.client(
     "s3",
-    endpoint_url=os.environ["S3_ENDPOINT"],  # http://minio.zeabur.internal:9000
+    endpoint_url=os.environ["S3_ENDPOINT"],
     aws_access_key_id=os.environ["S3_ACCESS_KEY"],
     aws_secret_access_key=os.environ["S3_SECRET_KEY"],
     region_name="us-east-1",
 )
-# boto3 uses path style by default when endpoint_url is set
 ```
 
 ```go
@@ -132,58 +177,17 @@ cfg, _ := config.LoadDefaultConfig(ctx,
     ),
 )
 client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-    o.BaseEndpoint = aws.String(endpoint) // http://minio.zeabur.internal:9000
+    o.BaseEndpoint = aws.String(endpoint)
     o.UsePathStyle = true
 })
 ```
 
 ---
 
-## Web Console
-
-Both MinIO and RustFS provide a web console for managing buckets and files:
-
-- **MinIO:** Console URL is in `MINIO_CONSOLE_URL`. Login with `MINIO_USERNAME` / `MINIO_PASSWORD`. The MinIO template auto-creates a `zeabur` default bucket.
-- **RustFS:** Console is on the domain bound to port `9001`. Login with `RUSTFS_USERNAME` / `RUSTFS_PASSWORD`. **You must create a bucket manually** before the app can upload files.
-
----
-
-## External Access (from local machine)
-
-MinIO and RustFS ports are **HTTP type** (not TCP), so they are accessed via **domain binding** through Zeabur's reverse proxy — **not** via port forwarding.
-
-Use `service instruction` to get the resolved external connection info:
-
-```bash
-npx zeabur@latest service instruction --id <storage-service-id> -i=false
-```
-
-This outputs the console URL and credentials with real values substituted.
-
-For the **S3 API endpoint**, the API port is also HTTP and served via the bound domain. Use the domain URL as the S3 endpoint (e.g., `https://minio-api.zeabur.app`). If no domain is bound to the API port, bind one via the Dashboard or use the `zeabur-domain-url` skill.
-
-Use the external S3 endpoint with local tools:
-
-```bash
-# MinIO Client (mc)
-mc alias set zeabur https://MINIO_API_DOMAIN ACCESS_KEY SECRET_KEY
-mc ls zeabur/
-mc mb zeabur/my-bucket
-mc cp local-file.txt zeabur/my-bucket/
-
-# AWS CLI
-aws --endpoint-url https://MINIO_API_DOMAIN s3 ls
-aws --endpoint-url https://MINIO_API_DOMAIN s3 mb s3://my-bucket
-```
-
----
-
 ## Caveats
 
-1. **`forcePathStyle` is required** — MinIO and RustFS use path-style URLs (`http://host:9000/bucket/key`). Without `forcePathStyle: true` (or equivalent), S3 SDKs default to virtual-hosted-style (`http://bucket.host:9000/key`) which won't resolve on internal networks. This is the #1 cause of "bucket not found" or DNS errors.
-2. **Create bucket before uploading (RustFS)** — Unlike the MinIO template which auto-creates a `zeabur` default bucket, RustFS starts with zero buckets. The app will get a `NoSuchBucket` error if the bucket doesn't exist. Create it via the web console or programmatically with `CreateBucket` API.
-3. **S3 endpoint is not a template variable** — Neither MinIO nor RustFS templates expose the S3 API endpoint as an env var. For **inter-service** (internal) access, set it manually as `http://<service-name>.zeabur.internal:9000`. For **external** access, bind a domain to the API port and use that domain URL.
-4. **Ports are HTTP, not TCP** — Both MinIO and RustFS templates declare their ports as HTTP type. This means they go through Zeabur's reverse proxy and are accessed via domain binding — **not** via port forwarding. `service network` will NOT show forwarded ports for these services.
-5. **Console vs API ports** — MinIO uses port `9000` for S3 API and port `9090` for web console. RustFS uses `9000` for API and `9001` for console. Applications should connect to the API port, not the console port.
-6. **Data persistence** — Storage templates include volumes. Uploaded files survive restarts.
-7. **Large file uploads** — If uploads fail or timeout, check the app's request size limits (e.g., Nginx `client_max_body_size`, Express `bodyParser.limit`). The storage service itself has no practical upload limit.
+1. **`forcePathStyle` is required** — Without it, S3 SDKs use virtual-hosted-style URLs (`http://bucket.host:9000/key`) which won't resolve. This is the #1 cause of "bucket not found" errors.
+2. **Create bucket before uploading (RustFS)** — MinIO auto-creates a `zeabur` bucket; RustFS does not. Create one via the console or `mc mb`.
+3. **S3 endpoint is not a template variable** — Hardcode it using the hostname from `service network` (internal) or the bound domain (external).
+4. **Variable references** — Zeabur uses a flat namespace. Set `${MINIO_USERNAME}` etc. via the **Zeabur Dashboard** — the CLI has a known bug with `${}` expansion.
+5. **Console vs API ports** — MinIO: API `9000`, console `9090`. RustFS: API `9000`, console `9001`. Apps connect to the API port.

--- a/skills/zeabur-object-storage/SKILL.md
+++ b/skills/zeabur-object-storage/SKILL.md
@@ -148,26 +148,32 @@ Both MinIO and RustFS provide a web console for managing buckets and files:
 
 ---
 
-## Local Connection (Port Forwarding)
+## External Access (from local machine)
 
-To access the S3 API or console from your local machine, get the forwarded host:port:
+MinIO and RustFS ports are **HTTP type** (not TCP), so they are accessed via **domain binding** through Zeabur's reverse proxy — **not** via port forwarding.
+
+Use `service instruction` to get the resolved external connection info:
 
 ```bash
-npx zeabur@latest service network --id <storage-service-id>
+npx zeabur@latest service instruction --id <storage-service-id> -i=false
 ```
 
-Use the forwarded endpoint with local tools:
+This outputs the console URL and credentials with real values substituted.
+
+For the **S3 API endpoint**, the API port is also HTTP and served via the bound domain. Use the domain URL as the S3 endpoint (e.g., `https://minio-api.zeabur.app`). If no domain is bound to the API port, bind one via the Dashboard or use the `zeabur-domain-url` skill.
+
+Use the external S3 endpoint with local tools:
 
 ```bash
 # MinIO Client (mc)
-mc alias set zeabur http://FORWARDED_HOST:FORWARDED_PORT ACCESS_KEY SECRET_KEY
+mc alias set zeabur https://MINIO_API_DOMAIN ACCESS_KEY SECRET_KEY
 mc ls zeabur/
 mc mb zeabur/my-bucket
 mc cp local-file.txt zeabur/my-bucket/
 
 # AWS CLI
-aws --endpoint-url http://FORWARDED_HOST:FORWARDED_PORT s3 ls
-aws --endpoint-url http://FORWARDED_HOST:FORWARDED_PORT s3 mb s3://my-bucket
+aws --endpoint-url https://MINIO_API_DOMAIN s3 ls
+aws --endpoint-url https://MINIO_API_DOMAIN s3 mb s3://my-bucket
 ```
 
 ---
@@ -175,8 +181,9 @@ aws --endpoint-url http://FORWARDED_HOST:FORWARDED_PORT s3 mb s3://my-bucket
 ## Caveats
 
 1. **`forcePathStyle` is required** — MinIO and RustFS use path-style URLs (`http://host:9000/bucket/key`). Without `forcePathStyle: true` (or equivalent), S3 SDKs default to virtual-hosted-style (`http://bucket.host:9000/key`) which won't resolve on internal networks. This is the #1 cause of "bucket not found" or DNS errors.
-2. **Create bucket before uploading (RustFS)** — Unlike the MinIO template which auto-creates a `zeabur` bucket, RustFS starts with zero buckets. The app will get a `NoSuchBucket` error if the bucket doesn't exist. Create it via the web console or programmatically with `CreateBucket` API.
-3. **S3 endpoint is not a template variable** — Neither MinIO nor RustFS templates expose the S3 API endpoint as an env var. You must set it manually as `http://<service-name>.zeabur.internal:9000` in the app's env vars.
-4. **Data persistence** — Storage templates include volumes. Uploaded files survive restarts.
+2. **Create bucket before uploading (RustFS)** — Unlike the MinIO template which auto-creates a `zeabur` default bucket, RustFS starts with zero buckets. The app will get a `NoSuchBucket` error if the bucket doesn't exist. Create it via the web console or programmatically with `CreateBucket` API.
+3. **S3 endpoint is not a template variable** — Neither MinIO nor RustFS templates expose the S3 API endpoint as an env var. For **inter-service** (internal) access, set it manually as `http://<service-name>.zeabur.internal:9000`. For **external** access, bind a domain to the API port and use that domain URL.
+4. **Ports are HTTP, not TCP** — Both MinIO and RustFS templates declare their ports as HTTP type. This means they go through Zeabur's reverse proxy and are accessed via domain binding — **not** via port forwarding. `service network` will NOT show forwarded ports for these services.
 5. **Console vs API ports** — MinIO uses port `9000` for S3 API and port `9090` for web console. RustFS uses `9000` for API and `9001` for console. Applications should connect to the API port, not the console port.
-6. **Large file uploads** — If uploads fail or timeout, check the app's request size limits (e.g., Nginx `client_max_body_size`, Express `bodyParser.limit`). The storage service itself has no practical upload limit.
+6. **Data persistence** — Storage templates include volumes. Uploaded files survive restarts.
+7. **Large file uploads** — If uploads fail or timeout, check the app's request size limits (e.g., Nginx `client_max_body_size`, Express `bodyParser.limit`). The storage service itself has no practical upload limit.

--- a/skills/zeabur-object-storage/SKILL.md
+++ b/skills/zeabur-object-storage/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: zeabur-object-storage
+description: Use when deploying object storage (S3-compatible) to Zeabur. Use when user needs MinIO, RustFS, or S3-compatible storage. Use when user says "object storage", "file storage", "S3", "MinIO", "RustFS", "upload files", "store files", "blob storage", or "OSS". Also use when integrating object storage with an existing service.
+---
+
+# Zeabur Object Storage Deployment
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+Deploy an S3-compatible object storage service (MinIO or RustFS) to the user's Zeabur project, then help them integrate it with their application.
+
+## Step 1 — Choose the Right Storage
+
+| User Need | Service | Image | Notes |
+|-----------|---------|-------|-------|
+| Full-featured S3, web console, IAM, versioning | MinIO | `minio/minio:RELEASE.2025-02-28T09-55-16Z` | Feature-rich, higher memory (~512MB+) |
+| Lightweight S3-compatible storage | RustFS | `rustfs/rustfs:0.1.1` | Minimal footprint, fast, S3-compatible |
+
+- **Default to MinIO** if the user doesn't specify — it's the most widely supported and has a built-in web console.
+- **Recommend RustFS** if the user wants lightweight/minimal or mentions RustFS specifically.
+
+## Step 2 — Identify the Target Project
+
+The storage service must be deployed into a project. Use the `zeabur-service-list` skill or ask the user for their project ID.
+
+```bash
+npx zeabur@latest service list --project-id <project-id>
+```
+
+## Step 3 — Write and Deploy the Template
+
+Create a template YAML file and deploy it to the user's project:
+
+```bash
+npx zeabur@latest template deploy -f object-storage.yaml -i=false --project-id <project-id>
+```
+
+### MinIO
+
+```yaml
+# yaml-language-server: $schema=https://schema.zeabur.app/template.json
+apiVersion: zeabur.com/v1
+kind: Template
+metadata:
+  name: MinIO
+spec:
+  description: S3-compatible object storage with web console
+  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/minio.svg
+  tags:
+    - Storage
+  variables:
+    - key: CONSOLE_DOMAIN
+      type: DOMAIN
+      name: MinIO Console Domain
+      description: Domain for the MinIO web console
+  readme: ""
+  services:
+    - name: minio
+      icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/minio.svg
+      template: PREBUILT_V2
+      domainKey:
+        - port: console
+          variable: CONSOLE_DOMAIN
+      spec:
+        source:
+          image: minio/minio:RELEASE.2025-02-28T09-55-16Z
+          command:
+            - minio
+            - server
+            - /data
+            - --console-address
+            - ":9001"
+        ports:
+          - id: api
+            port: 9000
+            type: TCP
+          - id: console
+            port: 9001
+            type: HTTP
+        portForwarding:
+          enabled: true
+        volumes:
+          - id: data
+            dir: /data
+        env:
+          MINIO_ROOT_USER:
+            default: minioadmin
+            expose: true
+          MINIO_ROOT_PASSWORD:
+            default: ${PASSWORD}
+            expose: true
+          MINIO_HOST:
+            default: ${CONTAINER_HOSTNAME}
+            expose: true
+            readonly: true
+          MINIO_PORT:
+            default: ${API_PORT}
+            expose: true
+            readonly: true
+          MINIO_ENDPOINT:
+            default: http://${MINIO_HOST}:${MINIO_PORT}
+            expose: true
+            readonly: true
+```
+
+### RustFS
+
+```yaml
+# yaml-language-server: $schema=https://schema.zeabur.app/template.json
+apiVersion: zeabur.com/v1
+kind: Template
+metadata:
+  name: RustFS
+spec:
+  description: Lightweight S3-compatible object storage
+  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/rustfs.svg
+  tags:
+    - Storage
+  variables:
+    - key: CONSOLE_DOMAIN
+      type: DOMAIN
+      name: RustFS Console Domain
+      description: Domain for the RustFS web console
+  readme: ""
+  services:
+    - name: rustfs
+      icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/rustfs.svg
+      template: PREBUILT_V2
+      domainKey:
+        - port: console
+          variable: CONSOLE_DOMAIN
+      spec:
+        source:
+          image: rustfs/rustfs:0.1.1
+          command:
+            - rustfs
+            - server
+            - /data
+            - --console-address
+            - ":9001"
+        ports:
+          - id: api
+            port: 9000
+            type: TCP
+          - id: console
+            port: 9001
+            type: HTTP
+        portForwarding:
+          enabled: true
+        volumes:
+          - id: data
+            dir: /data
+        env:
+          RUSTFS_ROOT_USER:
+            default: minioadmin
+            expose: true
+          RUSTFS_ROOT_PASSWORD:
+            default: ${PASSWORD}
+            expose: true
+          RUSTFS_HOST:
+            default: ${CONTAINER_HOSTNAME}
+            expose: true
+            readonly: true
+          RUSTFS_PORT:
+            default: ${API_PORT}
+            expose: true
+            readonly: true
+          RUSTFS_ENDPOINT:
+            default: http://${RUSTFS_HOST}:${RUSTFS_PORT}
+            expose: true
+            readonly: true
+```
+
+## Step 4 — Access the Web Console
+
+Both MinIO and RustFS provide a web console for managing buckets and files.
+
+1. After deployment, a domain will be assigned for the console. Check it with:
+   ```bash
+   npx zeabur@latest service list --project-id <project-id>
+   ```
+
+2. Open the console URL in a browser and log in with the root credentials:
+   - **MinIO:** user `minioadmin`, password from `MINIO_ROOT_PASSWORD`
+   - **RustFS:** user `minioadmin`, password from `RUSTFS_ROOT_PASSWORD`
+
+3. Create a bucket in the console before your application can upload files.
+
+## Step 5 — Integrate with Application
+
+After deploying, set S3-compatible env vars on the application service. Use the `zeabur-variables` skill.
+
+### Connection Variables
+
+| Service | Variable | Example Value |
+|---------|----------|---------------|
+| MinIO | `MINIO_ENDPOINT` | `http://minio.zeabur.internal:9000` |
+| MinIO | `MINIO_ROOT_USER` | `minioadmin` |
+| MinIO | `MINIO_ROOT_PASSWORD` | (auto-generated) |
+| RustFS | `RUSTFS_ENDPOINT` | `http://rustfs.zeabur.internal:9000` |
+| RustFS | `RUSTFS_ROOT_USER` | `minioadmin` |
+| RustFS | `RUSTFS_ROOT_PASSWORD` | (auto-generated) |
+
+### Common Application Env Var Mapping
+
+Most apps and SDKs use the standard AWS S3 env var names. Map them to the storage service variables:
+
+| App Env Var | Value (MinIO) | Value (RustFS) |
+|-------------|---------------|----------------|
+| `S3_ENDPOINT` or `AWS_ENDPOINT_URL` | `${MINIO.MINIO_ENDPOINT}` | `${RUSTFS.RUSTFS_ENDPOINT}` |
+| `S3_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` | `${MINIO.MINIO_ROOT_USER}` | `${RUSTFS.RUSTFS_ROOT_USER}` |
+| `S3_SECRET_KEY` or `AWS_SECRET_ACCESS_KEY` | `${MINIO.MINIO_ROOT_PASSWORD}` | `${RUSTFS.RUSTFS_ROOT_PASSWORD}` |
+| `S3_BUCKET` | (bucket name created in console) | (bucket name created in console) |
+| `S3_REGION` | `us-east-1` (default, any value works) | `us-east-1` |
+| `S3_FORCE_PATH_STYLE` | `true` | `true` |
+
+> **Important:** `S3_FORCE_PATH_STYLE=true` (or `forcePathStyle: true` in SDK config) is required for MinIO/RustFS. Without it, the SDK will try virtual-hosted-style URLs which won't resolve.
+
+> **Cross-service variable references** (e.g., `${MINIO.MINIO_ENDPOINT}`) should be set via the Zeabur Dashboard or GraphQL API — the CLI has a known issue with `${}` expansion. See the `zeabur-variables` skill for details.
+
+## Step 6 — Verify
+
+1. Check that the storage service is running:
+   ```bash
+   npx zeabur@latest deployment log --service-id <storage-service-id>
+   ```
+
+2. Test S3 API connectivity from the application container:
+   ```bash
+   # MinIO
+   npx zeabur@latest service exec --id <app-service-id> -- nc -z minio.zeabur.internal 9000
+
+   # RustFS
+   npx zeabur@latest service exec --id <app-service-id> -- nc -z rustfs.zeabur.internal 9000
+   ```
+
+3. Test with a simple S3 operation (if `curl` is available in the app container):
+   ```bash
+   npx zeabur@latest service exec --id <app-service-id> -- \
+     curl -s -o /dev/null -w "%{http_code}" http://minio.zeabur.internal:9000/minio/health/live
+   ```
+
+## Tips
+
+- **External API access:** The S3 API port uses TCP with port forwarding enabled. Get the external endpoint with `npx zeabur@latest service network --id <service-id>`.
+- **Data persistence:** Both templates include volumes. Uploaded files survive restarts.
+- **Bucket creation via CLI:** If `mc` (MinIO Client) is available:
+  ```bash
+  npx zeabur@latest service exec --id <storage-service-id> -- \
+    mc alias set local http://localhost:9000 minioadmin PASSWORD && \
+    mc mb local/my-bucket
+  ```
+- **SDK examples** — Most S3 SDKs just need endpoint + credentials + `forcePathStyle`:
+  ```javascript
+  // Node.js (AWS SDK v3)
+  const { S3Client } = require("@aws-sdk/client-s3");
+  const s3 = new S3Client({
+    endpoint: process.env.S3_ENDPOINT,
+    credentials: {
+      accessKeyId: process.env.S3_ACCESS_KEY,
+      secretAccessKey: process.env.S3_SECRET_KEY,
+    },
+    region: "us-east-1",
+    forcePathStyle: true,
+  });
+  ```

--- a/skills/zeabur-object-storage/SKILL.md
+++ b/skills/zeabur-object-storage/SKILL.md
@@ -9,25 +9,18 @@ description: Use when deploying object storage (S3-compatible) to Zeabur. Use wh
 
 ## Deploy Object Storage
 
-Search and deploy an object storage template:
+> **Before deploying, you MUST load the `zeabur-template` skill first** to understand what Zeabur templates are, how they work, and how to deploy them. This skill only covers object storage-specific integration — all template knowledge lives in `zeabur-template`.
+
+Search for a storage template:
 
 ```bash
-# Search for a storage template (minio, rustfs)
 npx zeabur@latest template search minio -i=false --json
-
-# Inspect a template's full definition (env vars, volumes, ports)
-npx zeabur@latest template get -c <TEMPLATE_CODE> --raw
-
-# Deploy to the user's project
-npx zeabur@latest template deploy -c <TEMPLATE_CODE> -i=false --project-id <project-id>
 ```
 
 Pick the template with the highest deployment count.
 
 - **Default to MinIO** if the user doesn't specify — most widely supported, built-in web console.
 - **Recommend RustFS** if the user wants lightweight/minimal or mentions RustFS.
-
-> For creating a custom storage template from scratch, use the `zeabur-template` skill.
 
 ---
 

--- a/skills/zeabur-object-storage/SKILL.md
+++ b/skills/zeabur-object-storage/SKILL.md
@@ -3,125 +3,166 @@ name: zeabur-object-storage
 description: Use when deploying object storage (S3-compatible) to Zeabur. Use when user needs MinIO, RustFS, or S3-compatible storage. Use when user says "object storage", "file storage", "S3", "MinIO", "RustFS", "upload files", "store files", "blob storage", or "OSS". Also use when integrating object storage with an existing service.
 ---
 
-# Zeabur Object Storage Deployment
+# Zeabur Object Storage Deployment & Integration
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
 
-Deploy an S3-compatible object storage service (MinIO or RustFS) to the user's Zeabur project via an existing template, then help them integrate it with their application.
+## Deploy Object Storage
 
-## Step 1 — Choose the Right Storage
-
-| User Need | Search Keyword | Notes |
-|-----------|---------------|-------|
-| Full-featured S3, web console, IAM, versioning | `minio` | Feature-rich, higher memory (~512MB+) |
-| Lightweight S3-compatible storage | `rustfs` | Minimal footprint, fast, S3-compatible |
-
-- **Default to MinIO** if the user doesn't specify — it's the most widely supported and has a built-in web console.
-- **Recommend RustFS** if the user wants lightweight/minimal or mentions RustFS specifically.
-
-## Step 2 — Find the Template
-
-Search for existing object storage templates on Zeabur:
+Search and deploy an object storage template:
 
 ```bash
+# Search for a storage template (minio, rustfs)
 npx zeabur@latest template search minio -i=false --json
-```
 
-This returns a JSON array of matching templates. Pick the one with the highest deployment count (more battle-tested). Note the `code` field — you'll need it to deploy.
-
-To inspect a template's full YAML (service definitions, env vars, volumes, etc.):
-
-```bash
+# Inspect a template's full definition (env vars, volumes, ports)
 npx zeabur@latest template get -c <TEMPLATE_CODE> --raw
-```
 
-> For advanced customization or creating a template from scratch, use the `zeabur-template` skill.
-
-## Step 3 — Identify the Target Project
-
-The storage service must be deployed into a project. Use the `zeabur-service-list` skill or ask the user for their project ID.
-
-```bash
-npx zeabur@latest service list --project-id <project-id>
-```
-
-## Step 4 — Deploy the Template
-
-Deploy the storage template into the user's project:
-
-```bash
+# Deploy to the user's project
 npx zeabur@latest template deploy -c <TEMPLATE_CODE> -i=false --project-id <project-id>
 ```
 
-## Step 5 — Access the Web Console
+Pick the template with the highest deployment count.
 
-Both MinIO and RustFS provide a web console for managing buckets and files.
+- **Default to MinIO** if the user doesn't specify — most widely supported, built-in web console.
+- **Recommend RustFS** if the user wants lightweight/minimal or mentions RustFS.
 
-1. After deployment, a domain will be assigned for the console. Check it with:
+> For creating a custom storage template from scratch, use the `zeabur-template` skill.
+
+---
+
+## Retrieve Connection Parameters
+
+After deploying, list the storage service's variables:
+
+```bash
+npx zeabur@latest variable list --id <storage-service-id> -i=false
+```
+
+Common variables exposed by storage templates:
+
+| Service | Key Variables | Description |
+|---------|--------------|-------------|
+| MinIO | `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `MINIO_HOST`, `MINIO_PORT`, `MINIO_ENDPOINT` | Endpoint is `http://<host>:<port>` |
+| RustFS | `RUSTFS_ROOT_USER`, `RUSTFS_ROOT_PASSWORD`, `RUSTFS_HOST`, `RUSTFS_PORT`, `RUSTFS_ENDPOINT` | Same pattern as MinIO |
+
+> **Variable names depend on the template.** Always run `variable list` to confirm the actual keys.
+
+---
+
+## Integrate with Application
+
+### Cross-service variable references
+
+In Zeabur, services can reference other services' exposed variables using the `${SERVICE_NAME.VAR_NAME}` syntax. For example, if the storage service is named `minio`:
+
+```
+${MINIO.MINIO_ENDPOINT}
+${MINIO.MINIO_ROOT_USER}
+${MINIO.MINIO_ROOT_PASSWORD}
+```
+
+> **CLI limitation:** The CLI has a known bug with `${}` expansion — cross-service references should be set via the **Zeabur Dashboard** or GraphQL API. See the `zeabur-variables` skill for details.
+
+### S3 SDK env var mapping
+
+Most S3-compatible SDKs use these standard env vars:
+
+| App Env Var | Value | Notes |
+|-------------|-------|-------|
+| `S3_ENDPOINT` or `AWS_ENDPOINT_URL` | `${MINIO.MINIO_ENDPOINT}` | Internal endpoint, e.g. `http://minio.zeabur.internal:9000` |
+| `S3_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` | `${MINIO.MINIO_ROOT_USER}` | |
+| `S3_SECRET_KEY` or `AWS_SECRET_ACCESS_KEY` | `${MINIO.MINIO_ROOT_PASSWORD}` | |
+| `S3_BUCKET` | (bucket name created in console) | Must create bucket first |
+| `S3_REGION` | `us-east-1` | Any value works, but must be set |
+| `S3_FORCE_PATH_STYLE` | `true` | **Required** — see caveats |
+
+### SDK code examples
+
+```javascript
+// Node.js (AWS SDK v3)
+const { S3Client } = require("@aws-sdk/client-s3");
+const s3 = new S3Client({
+  endpoint: process.env.S3_ENDPOINT,
+  credentials: {
+    accessKeyId: process.env.S3_ACCESS_KEY,
+    secretAccessKey: process.env.S3_SECRET_KEY,
+  },
+  region: "us-east-1",
+  forcePathStyle: true,
+});
+```
+
+```python
+# Python (boto3)
+import boto3
+s3 = boto3.client(
+    "s3",
+    endpoint_url=os.environ["S3_ENDPOINT"],
+    aws_access_key_id=os.environ["S3_ACCESS_KEY"],
+    aws_secret_access_key=os.environ["S3_SECRET_KEY"],
+    region_name="us-east-1",
+)
+# boto3 uses path style by default when endpoint_url is set
+```
+
+```go
+// Go (aws-sdk-go-v2)
+cfg, _ := config.LoadDefaultConfig(ctx,
+    config.WithRegion("us-east-1"),
+    config.WithCredentialsProvider(
+        credentials.NewStaticCredentialsProvider(accessKey, secretKey, ""),
+    ),
+)
+client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+    o.BaseEndpoint = aws.String(endpoint)
+    o.UsePathStyle = true
+})
+```
+
+---
+
+## Web Console
+
+Both MinIO and RustFS provide a web console (usually on port 9001) for managing buckets and files. After deployment:
+
+1. Check the service list for the console domain:
    ```bash
    npx zeabur@latest service list --project-id <project-id>
    ```
+2. Log in with root credentials (from `variable list`).
+3. **Create a bucket** before the application can upload files — most S3 SDKs don't auto-create buckets.
 
-2. Open the console URL in a browser and log in with the root credentials (check the template's env vars for the username and password).
+---
 
-3. Create a bucket in the console before your application can upload files.
+## Local Connection (Port Forwarding)
 
-## Step 6 — Integrate with Application
+The S3 API port (9000) is TCP with port forwarding auto-enabled. To get the external endpoint:
 
-After deploying, set S3-compatible env vars on the application service. Use the `zeabur-variables` skill.
+```bash
+npx zeabur@latest service network --id <storage-service-id>
+```
 
-> **Note:** The actual variable names depend on the template. Use `npx zeabur@latest template get -c <TEMPLATE_CODE> --raw` to check the exact env var names exposed by the template.
+Use the forwarded host:port to connect from local tools:
 
-### Common Application Env Var Mapping
+```bash
+# MinIO Client (mc)
+mc alias set zeabur http://FORWARDED_HOST:FORWARDED_PORT ACCESS_KEY SECRET_KEY
+mc ls zeabur/
+mc mb zeabur/my-bucket
+mc cp local-file.txt zeabur/my-bucket/
 
-Most apps and SDKs use the standard AWS S3 env var names. Map them to the storage service variables:
+# AWS CLI
+aws --endpoint-url http://FORWARDED_HOST:FORWARDED_PORT s3 ls
+aws --endpoint-url http://FORWARDED_HOST:FORWARDED_PORT s3 mb s3://my-bucket
+```
 
-| App Env Var | Description |
-|-------------|-------------|
-| `S3_ENDPOINT` or `AWS_ENDPOINT_URL` | The storage service's internal endpoint (e.g., `http://minio.zeabur.internal:9000`) |
-| `S3_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` | Root user from the storage service |
-| `S3_SECRET_KEY` or `AWS_SECRET_ACCESS_KEY` | Root password from the storage service |
-| `S3_BUCKET` | Bucket name created in the console |
-| `S3_REGION` | `us-east-1` (default, any value works) |
-| `S3_FORCE_PATH_STYLE` | `true` |
+---
 
-> **Important:** `S3_FORCE_PATH_STYLE=true` (or `forcePathStyle: true` in SDK config) is required for MinIO/RustFS. Without it, the SDK will try virtual-hosted-style URLs which won't resolve.
+## Caveats
 
-> **Cross-service variable references** (e.g., `${MINIO.MINIO_ENDPOINT}`) should be set via the Zeabur Dashboard or GraphQL API — the CLI has a known issue with `${}` expansion. See the `zeabur-variables` skill for details.
-
-## Step 7 — Verify
-
-1. Check that the storage service is running:
-   ```bash
-   npx zeabur@latest deployment log --service-id <storage-service-id>
-   ```
-
-2. Test S3 API connectivity from the application container:
-   ```bash
-   npx zeabur@latest service exec --id <app-service-id> -- nc -z minio.zeabur.internal 9000
-   ```
-
-3. Test with a simple health check (if `curl` is available in the app container):
-   ```bash
-   npx zeabur@latest service exec --id <app-service-id> -- \
-     curl -s -o /dev/null -w "%{http_code}" http://minio.zeabur.internal:9000/minio/health/live
-   ```
-
-## Tips
-
-- **External API access:** The S3 API port uses TCP with port forwarding enabled. Get the external endpoint with `npx zeabur@latest service network --id <service-id>`.
-- **Data persistence:** Storage templates include volumes. Uploaded files survive restarts.
-- **SDK examples** — Most S3 SDKs just need endpoint + credentials + `forcePathStyle`:
-  ```javascript
-  // Node.js (AWS SDK v3)
-  const { S3Client } = require("@aws-sdk/client-s3");
-  const s3 = new S3Client({
-    endpoint: process.env.S3_ENDPOINT,
-    credentials: {
-      accessKeyId: process.env.S3_ACCESS_KEY,
-      secretAccessKey: process.env.S3_SECRET_KEY,
-    },
-    region: "us-east-1",
-    forcePathStyle: true,
-  });
-  ```
+1. **`forcePathStyle` is required** — MinIO and RustFS use path-style URLs (`http://host:9000/bucket/key`). Without `forcePathStyle: true` (or equivalent), S3 SDKs default to virtual-hosted-style (`http://bucket.host:9000/key`) which won't resolve on internal networks. This is the #1 cause of "bucket not found" or DNS errors.
+2. **Create bucket before uploading** — Unlike managed S3, self-hosted storage starts with zero buckets. The app will get a `NoSuchBucket` error if the bucket doesn't exist. Create it via the web console, `mc mb`, or programmatically with `CreateBucket` API.
+3. **Data persistence** — Storage templates include volumes. Uploaded files survive restarts. If a user reports file loss, verify the template has a `volumes` section.
+4. **Console vs API ports** — The web console (port 9001, HTTP) and S3 API (port 9000, TCP) are separate. Applications should connect to the API port, not the console port.
+5. **Large file uploads** — If uploads fail or timeout, check the app's request size limits (e.g., Nginx `client_max_body_size`, Express `bodyParser.limit`). The storage service itself has no practical upload limit.

--- a/skills/zeabur-object-storage/SKILL.md
+++ b/skills/zeabur-object-storage/SKILL.md
@@ -19,8 +19,8 @@ npx zeabur@latest template search minio -i=false --json
 
 Pick the template with the highest deployment count.
 
-- **Default to MinIO** if the user doesn't specify — most widely supported, built-in web console.
-- **Recommend RustFS** if the user wants lightweight/minimal or mentions RustFS.
+- **Default to MinIO** if the user doesn't specify — most widely supported, built-in web console, auto-creates a default bucket.
+- **Recommend RustFS** if the user wants lightweight/minimal or mentions RustFS specifically.
 
 ---
 
@@ -32,14 +32,37 @@ After deploying, list the storage service's variables:
 npx zeabur@latest variable list --id <storage-service-id> -i=false
 ```
 
-Common variables exposed by storage templates:
+Exposed variables from the official Zeabur templates:
 
-| Service | Key Variables | Description |
-|---------|--------------|-------------|
-| MinIO | `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `MINIO_HOST`, `MINIO_PORT`, `MINIO_ENDPOINT` | Endpoint is `http://<host>:<port>` |
-| RustFS | `RUSTFS_ROOT_USER`, `RUSTFS_ROOT_PASSWORD`, `RUSTFS_HOST`, `RUSTFS_PORT`, `RUSTFS_ENDPOINT` | Same pattern as MinIO |
+### MinIO (template code: `TLJ3RL`)
 
-> **Variable names depend on the template.** Always run `variable list` to confirm the actual keys.
+| Variable | Description |
+|----------|-------------|
+| `MINIO_USERNAME` | Access Key ID (default: `minio`) |
+| `MINIO_PASSWORD` | Secret Access Key (auto-generated) |
+| `MINIO_CONSOLE_URL` | Full URL for the web console |
+| `MINIO_DEFAULT_BUCKET` | Default bucket name (default: `zeabur`) |
+
+The MinIO template exposes two HTTP ports:
+- **API** (port `9000`) — S3-compatible API, accessed internally as `http://minio.zeabur.internal:9000`
+- **Console** (port `9090`) — Web management UI, accessed via the domain in `MINIO_CONSOLE_URL`
+
+> **Note:** The MinIO template does **not** expose `MINIO_HOST`, `MINIO_PORT`, or `MINIO_ENDPOINT` variables. The internal S3 endpoint must be constructed manually: `http://minio.zeabur.internal:9000` (where `minio` is the service name).
+
+### RustFS (template code: `7FG0WI`)
+
+| Variable | Description |
+|----------|-------------|
+| `RUSTFS_USERNAME` | Access Key ID (default: `rustfs`) |
+| `RUSTFS_PASSWORD` | Secret Access Key (auto-generated) |
+
+The RustFS template exposes two HTTP ports:
+- **API** (port `9000`) — S3-compatible API, accessed internally as `http://rustfs.zeabur.internal:9000`
+- **Console** (port `9001`) — Web management UI
+
+> **Note:** The RustFS template does **not** expose HOST/PORT/ENDPOINT variables. Construct the internal endpoint manually: `http://rustfs.zeabur.internal:9000` (where `rustfs` or `RustFS` is the service name — check `service list` for the exact name).
+
+> **Variable names may differ across templates.** Always run `variable list` to confirm the actual keys.
 
 ---
 
@@ -50,25 +73,26 @@ Common variables exposed by storage templates:
 In Zeabur, services can reference other services' exposed variables using the `${SERVICE_NAME.VAR_NAME}` syntax. For example, if the storage service is named `minio`:
 
 ```
-${MINIO.MINIO_ENDPOINT}
-${MINIO.MINIO_ROOT_USER}
-${MINIO.MINIO_ROOT_PASSWORD}
+${MINIO.MINIO_USERNAME}
+${MINIO.MINIO_PASSWORD}
 ```
 
 > **CLI limitation:** The CLI has a known bug with `${}` expansion — cross-service references should be set via the **Zeabur Dashboard** or GraphQL API. See the `zeabur-variables` skill for details.
 
 ### S3 SDK env var mapping
 
-Most S3-compatible SDKs use these standard env vars:
+Most S3-compatible SDKs need these values:
 
-| App Env Var | Value | Notes |
-|-------------|-------|-------|
-| `S3_ENDPOINT` or `AWS_ENDPOINT_URL` | `${MINIO.MINIO_ENDPOINT}` | Internal endpoint, e.g. `http://minio.zeabur.internal:9000` |
-| `S3_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` | `${MINIO.MINIO_ROOT_USER}` | |
-| `S3_SECRET_KEY` or `AWS_SECRET_ACCESS_KEY` | `${MINIO.MINIO_ROOT_PASSWORD}` | |
-| `S3_BUCKET` | (bucket name created in console) | Must create bucket first |
-| `S3_REGION` | `us-east-1` | Any value works, but must be set |
-| `S3_FORCE_PATH_STYLE` | `true` | **Required** — see caveats |
+| App Env Var | MinIO Value | RustFS Value |
+|-------------|-------------|--------------|
+| `S3_ENDPOINT` or `AWS_ENDPOINT_URL` | `http://minio.zeabur.internal:9000` | `http://rustfs.zeabur.internal:9000` |
+| `S3_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` | `${MINIO.MINIO_USERNAME}` | `${RUSTFS.RUSTFS_USERNAME}` |
+| `S3_SECRET_KEY` or `AWS_SECRET_ACCESS_KEY` | `${MINIO.MINIO_PASSWORD}` | `${RUSTFS.RUSTFS_PASSWORD}` |
+| `S3_BUCKET` | `zeabur` (MinIO auto-creates this) | (must create bucket first) |
+| `S3_REGION` | `us-east-1` (any value works, but must be set) | `us-east-1` |
+| `S3_FORCE_PATH_STYLE` | `true` | `true` |
+
+> **Important:** The S3 endpoint must be hardcoded or set manually because the templates don't expose it as a variable. Use the internal hostname `<service-name>.zeabur.internal:9000`.
 
 ### SDK code examples
 
@@ -76,7 +100,7 @@ Most S3-compatible SDKs use these standard env vars:
 // Node.js (AWS SDK v3)
 const { S3Client } = require("@aws-sdk/client-s3");
 const s3 = new S3Client({
-  endpoint: process.env.S3_ENDPOINT,
+  endpoint: process.env.S3_ENDPOINT, // http://minio.zeabur.internal:9000
   credentials: {
     accessKeyId: process.env.S3_ACCESS_KEY,
     secretAccessKey: process.env.S3_SECRET_KEY,
@@ -91,7 +115,7 @@ const s3 = new S3Client({
 import boto3
 s3 = boto3.client(
     "s3",
-    endpoint_url=os.environ["S3_ENDPOINT"],
+    endpoint_url=os.environ["S3_ENDPOINT"],  # http://minio.zeabur.internal:9000
     aws_access_key_id=os.environ["S3_ACCESS_KEY"],
     aws_secret_access_key=os.environ["S3_SECRET_KEY"],
     region_name="us-east-1",
@@ -108,7 +132,7 @@ cfg, _ := config.LoadDefaultConfig(ctx,
     ),
 )
 client := s3.NewFromConfig(cfg, func(o *s3.Options) {
-    o.BaseEndpoint = aws.String(endpoint)
+    o.BaseEndpoint = aws.String(endpoint) // http://minio.zeabur.internal:9000
     o.UsePathStyle = true
 })
 ```
@@ -117,26 +141,22 @@ client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 
 ## Web Console
 
-Both MinIO and RustFS provide a web console (usually on port 9001) for managing buckets and files. After deployment:
+Both MinIO and RustFS provide a web console for managing buckets and files:
 
-1. Check the service list for the console domain:
-   ```bash
-   npx zeabur@latest service list --project-id <project-id>
-   ```
-2. Log in with root credentials (from `variable list`).
-3. **Create a bucket** before the application can upload files — most S3 SDKs don't auto-create buckets.
+- **MinIO:** Console URL is in `MINIO_CONSOLE_URL`. Login with `MINIO_USERNAME` / `MINIO_PASSWORD`. The MinIO template auto-creates a `zeabur` default bucket.
+- **RustFS:** Console is on the domain bound to port `9001`. Login with `RUSTFS_USERNAME` / `RUSTFS_PASSWORD`. **You must create a bucket manually** before the app can upload files.
 
 ---
 
 ## Local Connection (Port Forwarding)
 
-The S3 API port (9000) is TCP with port forwarding auto-enabled. To get the external endpoint:
+To access the S3 API or console from your local machine, get the forwarded host:port:
 
 ```bash
 npx zeabur@latest service network --id <storage-service-id>
 ```
 
-Use the forwarded host:port to connect from local tools:
+Use the forwarded endpoint with local tools:
 
 ```bash
 # MinIO Client (mc)
@@ -155,7 +175,8 @@ aws --endpoint-url http://FORWARDED_HOST:FORWARDED_PORT s3 mb s3://my-bucket
 ## Caveats
 
 1. **`forcePathStyle` is required** — MinIO and RustFS use path-style URLs (`http://host:9000/bucket/key`). Without `forcePathStyle: true` (or equivalent), S3 SDKs default to virtual-hosted-style (`http://bucket.host:9000/key`) which won't resolve on internal networks. This is the #1 cause of "bucket not found" or DNS errors.
-2. **Create bucket before uploading** — Unlike managed S3, self-hosted storage starts with zero buckets. The app will get a `NoSuchBucket` error if the bucket doesn't exist. Create it via the web console, `mc mb`, or programmatically with `CreateBucket` API.
-3. **Data persistence** — Storage templates include volumes. Uploaded files survive restarts. If a user reports file loss, verify the template has a `volumes` section.
-4. **Console vs API ports** — The web console (port 9001, HTTP) and S3 API (port 9000, TCP) are separate. Applications should connect to the API port, not the console port.
-5. **Large file uploads** — If uploads fail or timeout, check the app's request size limits (e.g., Nginx `client_max_body_size`, Express `bodyParser.limit`). The storage service itself has no practical upload limit.
+2. **Create bucket before uploading (RustFS)** — Unlike the MinIO template which auto-creates a `zeabur` bucket, RustFS starts with zero buckets. The app will get a `NoSuchBucket` error if the bucket doesn't exist. Create it via the web console or programmatically with `CreateBucket` API.
+3. **S3 endpoint is not a template variable** — Neither MinIO nor RustFS templates expose the S3 API endpoint as an env var. You must set it manually as `http://<service-name>.zeabur.internal:9000` in the app's env vars.
+4. **Data persistence** — Storage templates include volumes. Uploaded files survive restarts.
+5. **Console vs API ports** — MinIO uses port `9000` for S3 API and port `9090` for web console. RustFS uses `9000` for API and `9001` for console. Applications should connect to the API port, not the console port.
+6. **Large file uploads** — If uploads fail or timeout, check the app's request size limits (e.g., Nginx `client_max_body_size`, Express `bodyParser.limit`). The storage service itself has no practical upload limit.

--- a/skills/zeabur-object-storage/SKILL.md
+++ b/skills/zeabur-object-storage/SKILL.md
@@ -70,14 +70,14 @@ The RustFS template exposes two HTTP ports:
 
 ### Cross-service variable references
 
-In Zeabur, services can reference other services' exposed variables using the `${SERVICE_NAME.VAR_NAME}` syntax. For example, if the storage service is named `minio`:
+Zeabur uses a **flat variable namespace** — all exposed variables from every service in the same project are merged together. Your app can reference them directly by name, no service prefix needed:
 
 ```
-${MINIO.MINIO_USERNAME}
-${MINIO.MINIO_PASSWORD}
+${MINIO_USERNAME}
+${MINIO_PASSWORD}
 ```
 
-> **CLI limitation:** The CLI has a known bug with `${}` expansion — cross-service references should be set via the **Zeabur Dashboard** or GraphQL API. See the `zeabur-variables` skill for details.
+> **CLI limitation:** The CLI has a known bug with `${}` expansion — variable references should be set via the **Zeabur Dashboard**. See the `zeabur-variables` skill for details.
 
 ### S3 SDK env var mapping
 
@@ -86,8 +86,8 @@ Most S3-compatible SDKs need these values:
 | App Env Var | MinIO Value | RustFS Value |
 |-------------|-------------|--------------|
 | `S3_ENDPOINT` or `AWS_ENDPOINT_URL` | `http://minio.zeabur.internal:9000` | `http://rustfs.zeabur.internal:9000` |
-| `S3_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` | `${MINIO.MINIO_USERNAME}` | `${RUSTFS.RUSTFS_USERNAME}` |
-| `S3_SECRET_KEY` or `AWS_SECRET_ACCESS_KEY` | `${MINIO.MINIO_PASSWORD}` | `${RUSTFS.RUSTFS_PASSWORD}` |
+| `S3_ACCESS_KEY` or `AWS_ACCESS_KEY_ID` | `${MINIO_USERNAME}` | `${RUSTFS_USERNAME}` |
+| `S3_SECRET_KEY` or `AWS_SECRET_ACCESS_KEY` | `${MINIO_PASSWORD}` | `${RUSTFS_PASSWORD}` |
 | `S3_BUCKET` | `zeabur` (MinIO auto-creates this) | (must create bucket first) |
 | `S3_REGION` | `us-east-1` (any value works, but must be set) | `us-east-1` |
 | `S3_FORCE_PATH_STYLE` | `true` | `true` |

--- a/skills/zeabur-variables/SKILL.md
+++ b/skills/zeabur-variables/SKILL.md
@@ -80,7 +80,7 @@ npx zeabur@latest variable create --id <service-id> -k 'REDIS_URL=${REDIS_URI_IN
 # Or use GraphQL API with updateEnvironmentVariable(data: Map!) mutation
 ```
 
-For cross-service variable references like `${POSTGRESQL.POSTGRES_CONNECTION_STRING}`, **always use the Zeabur Dashboard** or the GraphQL API directly until the CLI bug is fixed.
+For cross-service variable references like `${POSTGRES_CONNECTION_STRING}` (Zeabur uses a flat namespace — all exposed variables from other services are merged directly, no service prefix needed), **always use the Zeabur Dashboard** until the CLI bug is fixed.
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary
- Add `zeabur-database` skill: deploy PostgreSQL, MySQL (MariaDB), MongoDB, or Redis with complete template YAMLs, framework-specific env var integration guides, and verification/debugging steps
- Add `zeabur-object-storage` skill: deploy MinIO or RustFS (S3-compatible) with web console + API ports, standard AWS S3 env var mapping, `forcePathStyle` guidance, and SDK examples
- Bump version to 1.17.0

## Test plan
- [ ] Install plugin and verify `zeabur-database` skill triggers on "I need a database" / "deploy postgres" / "add Redis"
- [ ] Install plugin and verify `zeabur-object-storage` skill triggers on "object storage" / "MinIO" / "S3"
- [ ] Deploy a PostgreSQL template via the skill and confirm service runs
- [ ] Deploy a MinIO template via the skill and confirm console is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI workflows to deploy and integrate PostgreSQL, MySQL/MariaDB, MongoDB, Redis, and S3-compatible object storage (MinIO, RustFS).

* **Documentation**
  * Added end-to-end guides with deployment steps, variable wiring, local access instructions, SDK/CLI examples, and a new "Database & Storage" category.

* **Chores**
  * Bumped plugin manifest version to 1.17.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->