### PR TITLE
docs: route version switches to tag update, not redeploy

### DIFF
--- a/skills/zeabur-deploy/SKILL.md
+++ b/skills/zeabur-deploy/SKILL.md
@@ -82,6 +82,8 @@ The response includes a `service_id`. **You MUST save this `service_id` for all 
 npx zeabur@latest deploy --project-id <project-id> --service-id <service-id> --json
 ```
 
+> **Do NOT use this flow for version upgrades / downgrades of prebuilt or marketplace services** (e.g. "upgrade PostgreSQL to 16", "downgrade n8n to 1.2"). That is a version switch, not a code redeploy — use the **`zeabur-update-service`** skill's tag update instead. Redeploying in place of a tag change can orphan or wipe the service's mounted disk.
+
 If no project exists yet, **invoke the `zeabur-project-create` skill** (do not run CLI commands directly).
 
 ## Git Deploy (On User Request)

--- a/skills/zeabur-update-service/SKILL.md
+++ b/skills/zeabur-update-service/SKILL.md
@@ -37,9 +37,11 @@ npx zeabur@latest service restart --id <service-id> -y -i=false
 |-------|----------|
 | `${VAR}` references | Set in Dashboard, not CLI (shell expands to empty) |
 
-## Update Image Tag (Upgrade Service Version)
+## Update Image Tag (Upgrade / Downgrade Service Version)
 
-For prebuilt/marketplace services, update the image tag to upgrade to a newer version.
+For prebuilt/marketplace services, update the image tag to switch versions.
+
+> **This is the ONLY correct path for version upgrades or downgrades.** Do NOT use `zeabur-deploy` (or any redeploy / delete-and-recreate flow) as a substitute — those flows can orphan or wipe the service's mounted disk. A tag update triggers a clean redeploy with the new image while the volume stays attached.
 
 ### Workflow
 


### PR DESCRIPTION
## Summary
- Cross-reference \`zeabur-update-service\` and \`zeabur-deploy\` so the agent does not reach for redeploy/delete-and-recreate flows when the user asks to upgrade or downgrade a prebuilt service's version.
- \`zeabur-update-service\`: mark tag update as the only correct path for version switches.
- \`zeabur-deploy\`: explicitly redirect version upgrades/downgrades to \`zeabur-update-service\`.

## Test plan
- [ ] Simulated: user asks to upgrade PostgreSQL to 16 → agent picks \`zeabur-update-service\` tag update, not \`zeabur-deploy --service-id\`.
- [ ] Simulated: user asks to redeploy a code change → agent still uses \`zeabur-deploy --service-id\` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified procedures for upgrading and downgrading service versions
  * Added important warnings about proper version switching to prevent data loss
  * Emphasized using tag updates instead of direct redeploy flows for version changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->