### PR TITLE
docs(deploy): document cwd, monorepo Dockerfile pattern, GIT-template caveat

### DIFF
--- a/skills/zeabur-deploy/SKILL.md
+++ b/skills/zeabur-deploy/SKILL.md
@@ -46,6 +46,8 @@ Zeabur supports two ways to deploy a project:
 
 Deploy the current local directory to Zeabur with one command.
 
+> **Run from the workspace root.** `zeabur deploy` tars the current working directory; if you are in a subdirectory the tarball will be missing files the build needs. For monorepos, this means `cd` to the repo root before deploying — even when deploying a single service. The tarball respects `.dockerignore` for excluding files like `.venv`, `node_modules`, nested git repos.
+
 ### Flags
 
 | Flag | Required | Description |
@@ -86,7 +88,32 @@ npx zeabur@latest deploy --project-id <project-id> --service-id <service-id> --j
 
 If no project exists yet, **invoke the `zeabur-project-create` skill** (do not run CLI commands directly).
 
+### Monorepo with multiple Dockerfiles
+
+If the project has more than one app to deploy (e.g. `apps/api` + `apps/jobs` each with its own Dockerfile in `infra/zeabur/`), do NOT keep swapping a root `zbpack.json` between deploys. Instead, set the per-service env var **`ZBPACK_DOCKERFILE_PATH`** which zbpack reads ahead of `zbpack.json`:
+
+```bash
+# After first deploy of each service, set the dockerfile path on that service
+npx zeabur@latest variable update --id <api-service-id> \
+  -k 'ZBPACK_DOCKERFILE_PATH=infra/zeabur/api.Dockerfile' -y -i=false
+
+npx zeabur@latest variable update --id <jobs-service-id> \
+  -k 'ZBPACK_DOCKERFILE_PATH=infra/zeabur/jobs.Dockerfile' -y -i=false
+```
+
+Subsequent `deploy --service-id <id>` redeploys then build with the right Dockerfile without any root config swap. The build context remains the workspace root, so the Dockerfile can `COPY infra/db/`, `COPY apps/<svc>/`, `COPY packages/` from the same context.
+
+If you do use `zbpack.json`, the schema is **nested**, not flat:
+
+```json
+{ "dockerfile": { "path": "infra/zeabur/api.Dockerfile" } }
+```
+
+`{"dockerfile": "..."}` (flat string) is silently ignored — zbpack falls back to language autodetection (e.g. `planType=python`) and the build won't use your Dockerfile.
+
 ## Git Deploy (On User Request)
+
+> **Caveat (observed 2026-04):** `service deploy --template GIT --repo-id ... --branch-name ...` accepts the flags and returns success, but the resulting service is created as `Template=PREBUILT_V2` with `Status=SUSPENDED` and `GitTrigger=null` — the Git source is NOT actually wired and `service redeploy` errors with `Internal Server Error`. Direct deploy is the working path. Only use Git deploy after you've confirmed the Zeabur GitHub App is installed on the org and the dashboard reflects a real Git binding for the service. If unsure, default to direct deploy.
 
 If the user explicitly wants Git-based deployment (e.g. for CI/CD, auto-redeploy on push):
 
@@ -151,3 +178,5 @@ Only guide the user through this flow when they specifically ask for Git-based d
 - For static sites, Zeabur auto-detects and serves them correctly.
 - **Always save both Project ID and Service ID** after first deploy. This prevents duplicate services on redeploy.
 - After deployment, use the `zeabur-deployment-logs` skill to check build and runtime logs.
+- **Don't retry a hung deploy without checking first.** If `zeabur deploy` looks stuck (no output for a while), the upload may already be in flight on Zeabur's side. Re-running creates a duplicate service. Check `service list` before retrying — the named service may already exist with a numeric or letter suffix appended (e.g. `api-toops` when you asked for `api`).
+- **Verify `planType=docker`** in the resulting deployment. Run `npx zeabur@latest deployment list --service-id <id> -i=false --json` after deploy and check the latest entry's `planType`. If it shows `python` / `nodejs` / etc. when you have a Dockerfile, zbpack didn't find your Dockerfile — most likely cause is the wrong cwd, the wrong `zbpack.json` schema, or the Dockerfile sitting outside the upload tarball.


### PR DESCRIPTION
## Summary

Adds five gotchas observed while deploying a Python uv-workspace monorepo (`apps/api` + `apps/jobs` with separate Dockerfiles under `infra/zeabur/`) to Zeabur via the CLI:

1. **Direct deploy must run from the workspace root.** `zeabur deploy` tars the current working directory; running from a subdir produces a tarball missing files the Dockerfile expects. Easy to miss after `cd`-ing into a subdir for testing.

2. **Monorepo with multiple Dockerfiles**: set per-service env var `ZBPACK_DOCKERFILE_PATH` (e.g. `infra/zeabur/api.Dockerfile`) instead of swapping a root `zbpack.json` between deploys. Env vars take precedence over `zbpack.json` (per zbpack source: `pkg/plan/config.go` env-var lookup runs before zbpack.json), so each service's redeploy works with no config swap.

3. **`zbpack.json` schema is nested**, not flat. `{\"dockerfile\": {\"path\": \"...\"}}` works; `{\"dockerfile\": \"...\"}` is silently ignored and zbpack falls back to language autodetection (`planType=python`, etc.). The flat form is what most users guess on first try.

4. **`service deploy --template GIT --repo-id ... --branch-name ...` is broken** in non-interactive mode (observed 2026-04 against CLI 0.15.0): the command returns success, but the resulting service is `Template=PREBUILT_V2` with `Status=SUSPENDED` and `GitTrigger=null` — the Git source is NOT actually wired. `service redeploy` then errors with `Internal Server Error`. Direct deploy is the working path.

5. **Tips additions**: don't retry a hung deploy without checking `service list` first (the upload may already be in flight; retrying creates a duplicate service with a numeric/letter suffix appended to the requested `--name`); verify `planType=docker` in the latest deployment after a Dockerfile-based deploy — if it shows `python`/`nodejs`/etc., zbpack didn't find your Dockerfile.

## Context

I hit each of these in sequence during a real session deploying a Postgres+Redis-backed FastAPI/uv-workspace monorepo to a fresh Zeabur project. The skill's existing direct-deploy section is good for the simple-app case but is silent on monorepos and on the `service deploy --template GIT` failure mode, which led to multiple wrongly-created services and ~30 min of CLI flailing before reading zbpack source.

## Test plan

- [x] Direct deploy from workspace root with `ZBPACK_DOCKERFILE_PATH` set per service: verified `planType=docker` and the right Dockerfile is built (api at infra/zeabur/api.Dockerfile, jobs at infra/zeabur/jobs.Dockerfile)
- [x] Verified flat `{\"dockerfile\": \"...\"}` zbpack.json is ignored (build went python plan); nested `{\"dockerfile\": {\"path\": \"...\"}}` works
- [x] Reproduced the `service deploy --template GIT` SUSPENDED-PREBUILT_V2 result, confirmed `GitTrigger=null` and `service redeploy` Internal Server Error
- [x] Reproduced duplicate-service creation when retrying a hung `zeabur deploy --name api` (got `api` and `api-toops` services)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded deployment documentation with workspace configuration requirements for multi-service setups
  * Added operational troubleshooting guidance for deployment verification
  * Documented known Git Deploy limitations affecting automatic redeploys

<!-- end of auto-generated comment: release notes by coderabbit.ai -->