### PR TITLE
docs(variables, database): working ${VAR} references + ZBPACK env vars

### DIFF
--- a/skills/zeabur-database/SKILL.md
+++ b/skills/zeabur-database/SKILL.md
@@ -158,7 +158,8 @@ Works with ioredis, redis-py, go-redis, and any Redis client.
 
 ## Caveats
 
-1. **Variable references** — Zeabur uses a flat namespace. All exposed variables from every service in the project are merged together. Your app references them directly by name (e.g., `${POSTGRES_HOST}`), no prefix needed. Set them via the **Zeabur Dashboard** — the CLI has a known bug with `${}` expansion.
-2. **Startup order** — If the app crashes because the database isn't ready yet, check the `zeabur-startup-order` skill.
-3. **Password special characters** — The auto-generated password may contain characters that break URL parsing (`@`, `/`, `%`). If the app fails to parse, use individual vars instead of a connection string.
-4. **Port forwarding disabled** — If `service network` shows port forwarding is disabled, enable it: `npx zeabur@latest service port-forward --id <id> --enable`
+1. **Variable references** — Zeabur uses a flat namespace. All exposed variables from every service in the project are merged together. Your app references them directly by name (e.g., `${POSTGRES_HOST}`), no prefix needed. **CLI updates DO work** for these references when single-quoted (observed 2026-04, see `zeabur-variables` skill for nuance) — `npx zeabur@latest variable update --id <svc> -k 'DATABASE_URL=postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}' -y -i=false` resolves correctly at injection time. The dashboard remains a reliable fallback for any unusual cases.
+2. **Custom URL schemes** — If your app needs a non-default driver prefix (e.g. SQLAlchemy + psycopg3 wants `postgresql+psycopg://`, not `postgresql://`), construct the URL by interpolating the parts (`${POSTGRES_USERNAME}`, etc.) rather than reusing the prebuilt `${POSTGRES_CONNECTION_STRING}` which always uses `postgresql://`.
+3. **Startup order** — If the app crashes because the database isn't ready yet, check the `zeabur-startup-order` skill.
+4. **Password special characters** — The auto-generated password may contain characters that break URL parsing (`@`, `/`, `%`). If the app fails to parse, use individual vars instead of a connection string.
+5. **Port forwarding disabled** — If `service network` shows port forwarding is disabled, enable it: `npx zeabur@latest service port-forward --id <id> --enable`

--- a/skills/zeabur-variables/SKILL.md
+++ b/skills/zeabur-variables/SKILL.md
@@ -67,20 +67,35 @@ After running `env`, you must restart the service manually to apply changes.
 
 ## Variable References
 
-> **Warning:** The CLI `-k` flag uses Cobra's `StringToStringVar` parser which cannot reliably handle values containing `${}`, even with single quotes. The value may be truncated or emptied. See [zeabur/cli#201](https://github.com/zeabur/cli/issues/201).
+> **Status (verified 2026-04):** Single-quoted `${VAR}` references via `update -k` DO get stored and DO resolve at injection time — no longer requiring the dashboard. Earlier reports of total breakage tracked in [zeabur/cli#201](https://github.com/zeabur/cli/issues/201) appear to be fixed for the common case. The Cobra parser can still mangle exotic values (commas inside the value, multiple `=` signs in a complex URL) — when in doubt, verify with `variable list` after the update and fall back to the dashboard if the stored value looks wrong.
 
 ```bash
-# WRONG — shell expands ${VAR} to empty
-npx zeabur@latest variable create --id <service-id> -k "REDIS_URL=${REDIS_URI_INTERNAL}" -y -i=false
+# WRONG — double quotes let the shell expand ${VAR} to empty before the CLI sees it
+npx zeabur@latest variable update --id <service-id> -k "REDIS_URL=${REDIS_URI_INTERNAL}" -y -i=false
 
-# STILL UNRELIABLE — single quotes prevent shell expansion but Cobra's CSV parser may still mangle the value
-npx zeabur@latest variable create --id <service-id> -k 'REDIS_URL=${REDIS_URI_INTERNAL}' -y -i=false
+# CORRECT — single quotes preserve ${VAR} so Zeabur resolves it at injection time
+npx zeabur@latest variable update --id <service-id> \
+  -k 'DATABASE_URL=postgresql+psycopg://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}' \
+  -k 'REDIS_URL=${REDIS_CONNECTION_STRING}' \
+  -y -i=false
 
-# RECOMMENDED — set variable references in Zeabur Dashboard
-# Or use GraphQL API with updateEnvironmentVariable(data: Map!) mutation
+# After updating, verify the stored value with variable list, then exec into the container
+# to confirm it resolved correctly: `service exec --id <id> -- env | grep DATABASE_URL`
 ```
 
-For cross-service variable references like `${POSTGRES_CONNECTION_STRING}` (Zeabur uses a flat namespace — all exposed variables from other services are merged directly, no service prefix needed), **always use the Zeabur Dashboard** until the CLI bug is fixed.
+Cross-service references work in a flat namespace — all exposed variables from other services in the project are merged directly, no service prefix needed (e.g. `${POSTGRES_HOST}` resolves regardless of which service exposes it).
+
+## zbpack build-time configuration via env vars
+
+For services that build from source, zbpack reads its config from BOTH `zbpack.json` AND service env vars (env vars take precedence). The most useful one for monorepo deploys:
+
+```bash
+# Tell zbpack to use a specific Dockerfile path (relative to upload tarball root)
+npx zeabur@latest variable update --id <service-id> \
+  -k 'ZBPACK_DOCKERFILE_PATH=infra/zeabur/api.Dockerfile' -y -i=false
+```
+
+The naming rule is `ZBPACK_<SCREAMING_SNAKE_CASE>` of the underlying config key — e.g. zbpack key `dockerfile.path` becomes env var `ZBPACK_DOCKERFILE_PATH`. This is preferable to swapping a root `zbpack.json` between deploys when the project has multiple services with different Dockerfiles.
 
 ## Quick Reference
 


### PR DESCRIPTION
## Summary

Two related corrections to bring the skills in line with the actual CLI behavior in version 0.15.0 (observed 2026-04):

### 1. `${VAR}` references via `variable update -k` DO work (when single-quoted)

The current `zeabur-variables` and `zeabur-database` skills route users to the dashboard for any cross-service variable reference, citing [zeabur/cli#201](https://github.com/zeabur/cli/issues/201) and labeling the CLI as broken for `\${}` values. In testing, single-quoted references via `variable update -k` are stored correctly and resolve at injection time:

\`\`\`bash
npx zeabur@latest variable update --id <service-id> \\
  -k 'DATABASE_URL=postgresql+psycopg://\${POSTGRES_USERNAME}:\${POSTGRES_PASSWORD}@\${POSTGRES_HOST}:\${POSTGRES_PORT}/\${POSTGRES_DATABASE}' \\
  -k 'REDIS_URL=\${REDIS_CONNECTION_STRING}' \\
  -y -i=false

# Verified by:
# - variable list — shows the literal \${...} stored
# - service exec ... -- env | grep DATABASE_URL — shows fully resolved value
\`\`\`

The skill is updated to:
- Soften the blanket warning
- Provide a working multi-key example
- Note that exotic values (commas inside the value, multiple `=` signs) may still trigger Cobra parser issues, so verifying with `variable list` after the update is prudent

This is the same direction as #50, which removed the now-stale "variable update clears vars" warning from `zeabur-update-service`.

### 2. New section: zbpack build-time config via env vars

Adds documentation that zbpack reads env vars (via `ZBPACK_<SCREAMING_SNAKE_CASE>` of the underlying config key) at build time. The most useful one for monorepos: `ZBPACK_DOCKERFILE_PATH=infra/zeabur/api.Dockerfile` per service.

This replaces the need to swap a root `zbpack.json` between deploys when the project has multiple services with different Dockerfiles. (See companion PR #56 for the full monorepo deploy story.)

### 3. zeabur-database tip on custom URL schemes

Replace the stale `${}` caveat with the corrected version, plus a tip: if your driver wants a non-default prefix (e.g. SQLAlchemy with psycopg3 wants `postgresql+psycopg://`, not `postgresql://`), construct the URL by interpolating the parts (`${POSTGRES_USERNAME}`, etc.) rather than reusing `${POSTGRES_CONNECTION_STRING}` which always uses `postgresql://`.

## Test plan

- [x] Set DATABASE_URL with 5 nested `\${...}` parts via `variable update -k` (single-quoted) — verified storage via `variable list` and resolution via `service exec ... -- env`
- [x] Set ZBPACK_DOCKERFILE_PATH on a service that previously fell back to python plan — next `zeabur deploy --service-id` build came up `planType=docker` with the right Dockerfile
- [x] Confirmed `${POSTGRES_CONNECTION_STRING}` always uses `postgresql://` prefix; constructing `postgresql+psycopg://` requires interpolating parts

🤖 Generated with [Claude Code](https://claude.com/claude-code)