### PR TITLE
docs(service-delete): document async deletion behavior

### DIFF
--- a/skills/zeabur-service-delete/SKILL.md
+++ b/skills/zeabur-service-delete/SKILL.md
@@ -43,4 +43,17 @@ npx zeabur@latest service list --project-id <project-id> -i=false --json
 npx zeabur@latest service delete -i=false --id <service-id> -y
 ```
 
+## Behavior to be aware of
+
+- **Deletion is async.** A successful `service delete` schedules the removal — the service typically continues to appear in `service list` for a while as `Status=SUSPENDED` until eventual consistency clears it. Don't panic if the list still shows it right after.
+- **Retrying a delete errors out.** If you call `service delete` a second time on a service whose first delete is already scheduled, the CLI returns:
+
+  ```
+  ERROR  delete service failed: Message: Resource already exists, ...
+         description:service deletion already scheduled or service not found
+  ```
+
+  This means the first delete worked. Treat this error as "already done", not as a failure.
+- **Confirming actual removal.** If you need to know whether a service is gone, query its status with `service get --id <id>` — once removed, the call returns "service not found". The `service list` output may lag behind by minutes.
+
 To delete an entire project instead, use the `zeabur-project-delete` skill.


### PR DESCRIPTION
## Summary

Adds a "Behavior to be aware of" section to `zeabur-service-delete` documenting three properties of the CLI's delete that are easy to misread as failures:

1. **Deletion is async.** A successful `service delete` schedules removal — the service typically continues to appear in `service list` as `Status=SUSPENDED` for some time before eventual consistency clears it. The skill currently implies delete is immediate, which led me to conclude the delete had failed when the service was still in the list.

2. **Retrying a delete errors with 'already scheduled'**, not because it failed. The CLI returns:

   \`\`\`
   ERROR  delete service failed: Message: Resource already exists, ...
          description:service deletion already scheduled or service not found
   \`\`\`

   The error is misleading — it actually confirms the first delete worked. Documenting this so agents don't loop trying to "fix" a successful delete.

3. **`service get --id <id>`** is the way to confirm actual removal — it returns "service not found" once the service is gone, while `service list` may still show it for minutes due to lag.

## Test plan

- [x] Reproduced async delete: ran `service delete -y -i=false` with success exit, but service appeared in `service list` for several minutes after with `Status=SUSPENDED`
- [x] Reproduced "already scheduled" error on retry of an already-deleted service
- [x] Confirmed `service get --id <id>` returns "service not found" once removal completes, while `service list` was still lagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)