### PR TITLE
docs(server-rent): warn against retrying hung rent commands

### DIFF
--- a/skills/zeabur-server-rent/SKILL.md
+++ b/skills/zeabur-server-rent/SKILL.md
@@ -13,6 +13,8 @@ description: Use when renting a new dedicated server. Use when user wants to buy
 npx zeabur@latest server rent --provider <code> --region <id> --plan <name> -y -i=false
 ```
 
+> **Run foreground and wait for output before retrying.** `server rent` is a billable action with no built-in idempotency — if the first call appears to hang and you re-issue it, you can end up with two servers (and two monthly charges). If the foreground command produces no output for a while, **do not retry**: instead poll `npx zeabur@latest server list -i=false --json` to see whether a new server has appeared. Only retry if `server list` confirms no new server was created. The CLI has no `server delete` subcommand — duplicates have to be removed via the dashboard at <https://zeabur.com/account/server>, so the cost of a wrongful retry is non-trivial.
+
 ## Workflow
 
 ### 1. Browse available options (use the `zeabur-server-catalog` skill for filtering)


### PR DESCRIPTION
## Summary

`server rent` is a billable action with no built-in idempotency. If the foreground command produces no output for a while and the agent re-issues it, both calls can succeed and you end up with two servers (and two monthly charges). I hit this exactly: a foreground rent command appeared hung, I retried, and `server list` then showed two new "Tencent Tokyo 2C 4GB" servers (one ID `...49`, the other `...4c`) created within seconds of each other.

The CLI has no `server delete` subcommand, so the only recovery is the dashboard at <https://zeabur.com/account/server>. Cost of a wrongful retry is non-trivial.

Adds an explicit warning to:
- Run foreground (not background)
- Wait for output before retrying
- Poll `server list -i=false --json` to see if a new server has appeared, rather than guessing whether the prior call succeeded

## Test plan

- [x] Reproduced double-rent: same `server rent --provider tencent --region ap-tokyo --plan ...` issued twice in quick succession produced two distinct servers, both billed
- [x] Confirmed CLI has no `server delete` subcommand (`server --help` lists only `catalog`, `get`, `list`, `plans`, `providers`, `reboot`, `regions`, `rent`, `ssh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)