### PR TITLE
fix: update deploy skill to use `service search-repo` for Git deploy

### DIFF
--- a/skills/zeabur-deploy/SKILL.md
+++ b/skills/zeabur-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-deploy
-description: Use when deploying a local project or codebase to Zeabur. Use when the user says "deploy this" or "deploy to Zeabur". Default to direct deploy unless the user explicitly asks for Git-based deployment.
+description: Use when deploying a local project or codebase to Zeabur. Use when the user says "deploy this", "deploy to Zeabur", "deploy from GitHub", "search my repos", or "find my repository". Default to direct deploy unless the user explicitly asks for Git-based deployment.
 ---
 
 # Zeabur Deploy
@@ -126,18 +126,15 @@ npx zeabur@latest service deploy --json -i=false \
 **Non-interactive (fully automated):**
 
 ```bash
-# 1. Push code to GitHub
-git init && git add . && git commit -m "Initial commit"
-gh repo create my-app --public --source=. --push
+# 1. Search for the user's GitHub repo
+npx zeabur@latest service search-repo <keyword> --json -i=false
+# Returns: [{"Name":"my-app","Owner":"user","URL":"...","ID":12345}, ...]
 
-# 2. Get GitHub repo ID (Zeabur uses GitHub's numeric repo ID)
-REPO_ID=$(gh api repos/OWNER/my-app --jq .id)
-
-# 3. Deploy from GitHub (PROJECT_ID must be known beforehand — see Prerequisites)
+# 2. Deploy from GitHub using the repo ID from search results
 npx zeabur@latest service deploy --json -i=false \
   --project-id $PROJECT_ID \
   --template GIT \
-  --repo-id $REPO_ID \
+  --repo-id <repo-id> \
   --branch-name main
 ```
 

--- a/skills/zeabur-deploy/SKILL.md
+++ b/skills/zeabur-deploy/SKILL.md
@@ -129,6 +129,8 @@ npx zeabur@latest service deploy --json -i=false \
 # 1. Search for the user's GitHub repo
 npx zeabur@latest service search-repo <keyword> --json -i=false
 # Returns: [{"Name":"my-app","Owner":"user","URL":"...","ID":12345}, ...]
+# If multiple results are returned, confirm the exact Owner/Name with the user.
+# Never pick the first result by default.
 
 # 2. Deploy from GitHub using the repo ID from search results
 npx zeabur@latest service deploy --json -i=false \

--- a/skills/zeabur-deploy/SKILL.md
+++ b/skills/zeabur-deploy/SKILL.md
@@ -123,14 +123,14 @@ npx zeabur@latest service deploy --json -i=false \
 
 ### Git Deploy Workflow
 
-**Non-interactive (fully automated):**
+**Git deploy workflow:**
 
 ```bash
 # 1. Search for the user's GitHub repo
 npx zeabur@latest service search-repo <keyword> --json -i=false
 # Returns: [{"Name":"my-app","Owner":"user","URL":"...","ID":12345}, ...]
-# If multiple results are returned, confirm the exact Owner/Name with the user.
-# Never pick the first result by default.
+# If multiple results are returned, ask the user which repo to deploy.
+# The agent (not the CLI) is responsible for disambiguation.
 
 # 2. Deploy from GitHub using the repo ID from search results
 npx zeabur@latest service deploy --json -i=false \


### PR DESCRIPTION
Replace `gh api` repo ID lookup with `zeabur service search-repo` so the agent can find repos without requiring gh CLI in the sandbox.

DES-534

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Broadened Zeabur deploy triggers to handle GitHub-related requests (e.g., deploy from GitHub, search repos).
  * Added integrated repository search to surface candidate repos and prompt when multiple matches exist.
  * Removed manual local repository creation from non-interactive Git deploys.
  * Deploys now use discovered repository identifiers directly while retaining project, template, and branch options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->