### PR TITLE
feat: add zeabur-server-ssh skill for SSH + kubectl debugging

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zeabur",
   "description": "Zeabur CLI skills for deployment, template management, and troubleshooting",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "author": {
     "name": "Can"
   },

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: zeabur-server-ssh
+description: Use when debugging services on a user's dedicated server via SSH. Use when needing to inspect pods, check container logs, view k8s resources, or run kubectl commands on the server. Use when "service exec" is insufficient and you need server-level access. Use when user says "check my server", "debug pod", "kubectl", "SSH into server", "check k8s", or "inspect cluster".
+---
+
+# Zeabur Server SSH + kubectl
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method.
+
+SSH into a user's dedicated server and use kubectl to debug Kubernetes workloads. Zeabur dedicated servers run k3s with kubectl pre-installed.
+
+## Step 1: Get SSH Credentials
+
+```bash
+npx zeabur@latest server ssh-info --id <server-id> -i=false
+```
+
+Output is JSON:
+```json
+{"ip":"1.2.3.4","port":22,"username":"root","password":"xxx"}
+```
+
+If you don't know the server ID, list servers first:
+```bash
+npx zeabur@latest server list -i=false
+```
+
+## Step 2: Run Commands via SSH
+
+Use `sshpass` to run commands non-interactively. Always combine multiple checks into a single SSH call to minimize overhead.
+
+```bash
+# Single command
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl get pods -A
+
+# Multiple commands in one SSH call (preferred)
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
+  echo "=== PODS ===" && kubectl get pods -A &&
+  echo "=== SERVICES ===" && kubectl get svc -A &&
+  echo "=== EVENTS ===" && kubectl get events -A --sort-by=.lastTimestamp | tail -20
+'
+```
+
+## Common kubectl Patterns
+
+### Check pod status and recent events
+```bash
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
+  echo "=== PODS ===" && kubectl get pods -A -o wide &&
+  echo "=== PROBLEM PODS ===" && kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded &&
+  echo "=== RECENT EVENTS ===" && kubectl get events -A --sort-by=.lastTimestamp | tail -30
+'
+```
+
+### View logs for a specific pod
+```bash
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl logs <pod-name> -n <namespace> --tail=100
+```
+
+### Exec into a container via kubectl
+```bash
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl exec <pod-name> -n <namespace> -- <command>
+```
+
+### Check resource usage
+```bash
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
+  echo "=== NODE RESOURCES ===" && kubectl top nodes &&
+  echo "=== POD RESOURCES ===" && kubectl top pods -A --sort-by=memory | head -20
+'
+```
+
+### Describe a failing pod
+```bash
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl describe pod <pod-name> -n <namespace>
+```
+
+### Restart a deployment
+```bash
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl rollout restart deployment/<deployment-name> -n <namespace>
+```
+
+## Tips
+
+- **Combine commands**: Always batch related checks into a single SSH call using single quotes with `&&` to reduce round trips.
+- **Do NOT use `bash -c '...'`**: Pass commands directly in SSH quotes. Using `bash -c` causes quoting conflicts over SSH.
+- **Use `-o wide`**: Adds node name and IP to pod listings, useful for debugging scheduling issues.
+- **Namespace matters**: Zeabur services typically run in non-default namespaces. Use `-A` (all namespaces) first to locate the right namespace, then scope subsequent commands with `-n <namespace>`.
+- **Read project docs first**: If a fix attempt fails, SSH into the container and check README or config files before blindly checking metrics: `kubectl exec <pod> -n <ns> -- cat /app/README.md`
+- **sshpass availability**: If `sshpass` is not installed in the sandbox, install it first: `apt-get update && apt-get install -y sshpass`
+- To find server IDs, use the `zeabur-server-list` skill. For simpler container commands that don't need server-level access, use the `zeabur-service-exec` skill instead.


### PR DESCRIPTION
## Summary
- Add `zeabur-server-ssh` skill for debugging services on dedicated servers via SSH + kubectl
- Uses `zeabur server ssh-info` (CLI v0.17.0) to get SSH credentials non-interactively
- Includes common kubectl patterns: pod status, logs, exec, resource usage, restart deployment
- Emphasizes command batching to minimize SSH round trips

Closes DES-627

## Test plan
- [x] SSH connection via `sshpass` + `server ssh-info` — verified on Linode 4C8G Tokyo
- [x] `kubectl get pods -A` — all pods Running
- [x] `kubectl top nodes` — resource usage normal
- [x] Combined commands pattern — no quoting issues
- [x] `bash -c` pattern confirmed broken over SSH — removed from skill, using direct SSH quotes instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782154939&installation_id=128583772&pr_number=63&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F63&signature=337df00e2cbbea6df356012db1f7642309cb233276919a2b5c53acb0614a229a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->