### PR TITLE
fix: replace sshpass with SSH_ASKPASS for sandbox compatibility

### DIFF
--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -25,16 +25,28 @@ If you don't know the server ID, list servers first:
 npx zeabur@latest server list -i=false
 ```
 
-## Step 2: Run Commands via SSH
+## Step 2: Set Up SSH_ASKPASS
 
-Use `sshpass` to run commands non-interactively. Always combine multiple checks into a single SSH call to minimize overhead.
+The sandbox does not have `sshpass`. Use `SSH_ASKPASS` instead — it is built into SSH and requires no extra packages.
+
+```bash
+# Create the askpass script (do this once per session)
+echo '#!/bin/sh
+echo "<password>"' > /tmp/askpass.sh && chmod +x /tmp/askpass.sh
+```
+
+Replace `<password>` with the actual password from Step 1.
+
+## Step 3: Run Commands via SSH
+
+Always combine multiple checks into a single SSH call to minimize overhead.
 
 ```bash
 # Single command
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl get pods -A
+SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl get pods -A
 
 # Multiple commands in one SSH call (preferred)
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
+SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
   echo "=== PODS ===" && kubectl get pods -A &&
   echo "=== SERVICES ===" && kubectl get svc -A &&
   echo "=== EVENTS ===" && kubectl get events -A --sort-by=.lastTimestamp | tail -20
@@ -45,7 +57,7 @@ sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip
 
 ### Check pod status and recent events
 ```bash
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
+SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
   echo "=== PODS ===" && kubectl get pods -A -o wide &&
   echo "=== PROBLEM PODS ===" && kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded &&
   echo "=== RECENT EVENTS ===" && kubectl get events -A --sort-by=.lastTimestamp | tail -30
@@ -54,17 +66,17 @@ sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip
 
 ### View logs for a specific pod
 ```bash
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl logs <pod-name> -n <namespace> --tail=100
+SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl logs <pod-name> -n <namespace> --tail=100
 ```
 
 ### Exec into a container via kubectl
 ```bash
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl exec <pod-name> -n <namespace> -- <command>
+SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl exec <pod-name> -n <namespace> -- <command>
 ```
 
 ### Check resource usage
 ```bash
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
+SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
   echo "=== NODE RESOURCES ===" && kubectl top nodes &&
   echo "=== POD RESOURCES ===" && kubectl top pods -A --sort-by=memory | head -20
 '
@@ -72,20 +84,21 @@ sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip
 
 ### Describe a failing pod
 ```bash
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl describe pod <pod-name> -n <namespace>
+SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl describe pod <pod-name> -n <namespace>
 ```
 
 ### Restart a deployment
 ```bash
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl rollout restart deployment/<deployment-name> -n <namespace>
+SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl rollout restart deployment/<deployment-name> -n <namespace>
 ```
 
 ## Tips
 
+- **Do NOT use `sshpass`**: It is not available in the sandbox. Use `SSH_ASKPASS` as shown above.
+- **Create askpass script once**: Run the `echo ... > /tmp/askpass.sh` command once, then reuse it for all subsequent SSH calls in the same session.
 - **Combine commands**: Always batch related checks into a single SSH call using single quotes with `&&` to reduce round trips.
 - **Do NOT use `bash -c '...'`**: Pass commands directly in SSH quotes. Using `bash -c` causes quoting conflicts over SSH.
 - **Use `-o wide`**: Adds node name and IP to pod listings, useful for debugging scheduling issues.
 - **Namespace matters**: Zeabur services typically run in non-default namespaces. Use `-A` (all namespaces) first to locate the right namespace, then scope subsequent commands with `-n <namespace>`.
 - **Read project docs first**: If a fix attempt fails, SSH into the container and check README or config files before blindly checking metrics: `kubectl exec <pod> -n <ns> -- cat /app/README.md`
-- **sshpass availability**: If `sshpass` is not installed in the sandbox, install it first: `apt-get update && apt-get install -y sshpass`
 - To find server IDs, use the `zeabur-server-list` skill. For simpler container commands that don't need server-level access, use the `zeabur-service-exec` skill instead.

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -31,11 +31,15 @@ The sandbox does not have `sshpass`. Use `SSH_ASKPASS` instead — it is built i
 
 ```bash
 # Create the askpass script (do this once per session)
-echo '#!/bin/sh
-echo "<password>"' > /tmp/askpass.sh && chmod +x /tmp/askpass.sh
+umask 077
+cat > /tmp/askpass.sh <<'ASKPASS'
+#!/bin/sh
+echo "<password>"
+ASKPASS
+chmod 700 /tmp/askpass.sh
 ```
 
-Replace `<password>` with the actual password from Step 1.
+Replace `<password>` with the actual password from Step 1. Clean up when done: `rm -f /tmp/askpass.sh`
 
 ## Step 3: Run Commands via SSH
 


### PR DESCRIPTION
## Summary
- Replace all `sshpass` usage with `SSH_ASKPASS` mechanism in the SSH skill
- `sshpass` and `apt-get` are not available in Vercel Sandbox, causing the agent to fail and waste multiple steps trying workarounds
- `SSH_ASKPASS` is built into SSH, requires zero extra packages, works in any environment

## What changed
- Added "Step 2: Set Up SSH_ASKPASS" — create askpass script once per session
- Replaced all `sshpass -p '<password>' ssh ...` patterns with `SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh ...`
- Updated Tips section: explicitly warns not to use `sshpass`

## Test plan
- [ ] Test in Vercel Sandbox via skilled agent conversation
- [ ] Verify SSH connection works without `sshpass`
- [ ] Verify kubectl commands execute correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782323312&installation_id=128583772&pr_number=64&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F64&signature=84ab61da87ee6868b6cc0748f28eee4a44419011b1695c7264e2241550735787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->