### PR TITLE
fix: use ssh2 Node.js library instead of sshpass/SSH_ASKPASS

### DIFF
--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -25,84 +25,74 @@ If you don't know the server ID, list servers first:
 npx zeabur@latest server list -i=false
 ```
 
-## Step 2: Set Up SSH_ASKPASS
+## Step 2: Run Commands via SSH
 
-The sandbox does not have `sshpass`. Use `SSH_ASKPASS` instead — it is built into SSH and requires no extra packages.
-
-```bash
-# Create the askpass script (do this once per session)
-umask 077
-cat > /tmp/askpass.sh <<'ASKPASS'
-#!/bin/sh
-echo "<password>"
-ASKPASS
-chmod 700 /tmp/askpass.sh
-```
-
-Replace `<password>` with the actual password from Step 1. Clean up when done: `rm -f /tmp/askpass.sh`
-
-## Step 3: Run Commands via SSH
-
-Always combine multiple checks into a single SSH call to minimize overhead.
+The sandbox has `ssh2` pre-installed. Use this Node.js one-liner to run commands via SSH:
 
 ```bash
-# Single command
-SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl get pods -A
-
-# Multiple commands in one SSH call (preferred)
-SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
-  echo "=== PODS ===" && kubectl get pods -A &&
-  echo "=== SERVICES ===" && kubectl get svc -A &&
-  echo "=== EVENTS ===" && kubectl get events -A --sort-by=.lastTimestamp | tail -20
-'
+node -e "
+const {Client} = require('/home/vercel-sandbox/.global/node_modules/ssh2');
+const c = new Client();
+c.on('ready', () => {
+  c.exec('<command>', (err, stream) => {
+    if (err) { console.error(err); process.exit(1); }
+    let out = '', errOut = '';
+    stream.on('data', d => out += d);
+    stream.stderr.on('data', d => errOut += d);
+    stream.on('close', code => {
+      if (out) console.log(out);
+      if (errOut) console.error(errOut);
+      c.end();
+      process.exit(code);
+    });
+  });
+}).connect({host:'<ip>', port:<port>, username:'<username>', password:'<password>'});
+"
 ```
 
-## Common kubectl Patterns
+Replace `<ip>`, `<port>`, `<username>`, `<password>`, and `<command>` with actual values from Step 1.
 
-### Check pod status and recent events
+### Combine multiple commands (preferred)
+
+Batch related checks into a single SSH call to minimize overhead:
+
 ```bash
-SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
-  echo "=== PODS ===" && kubectl get pods -A -o wide &&
-  echo "=== PROBLEM PODS ===" && kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded &&
-  echo "=== RECENT EVENTS ===" && kubectl get events -A --sort-by=.lastTimestamp | tail -30
-'
+node -e "
+const {Client} = require('/home/vercel-sandbox/.global/node_modules/ssh2');
+const c = new Client();
+c.on('ready', () => {
+  c.exec('echo \"=== PODS ===\" && kubectl get pods -A && echo \"=== SERVICES ===\" && kubectl get svc -A && echo \"=== EVENTS ===\" && kubectl get events -A --sort-by=.lastTimestamp | tail -20', (err, stream) => {
+    if (err) { console.error(err); process.exit(1); }
+    let out = '';
+    stream.on('data', d => out += d);
+    stream.stderr.on('data', d => out += d);
+    stream.on('close', () => { console.log(out); c.end(); });
+  });
+}).connect({host:'<ip>', port:<port>, username:'<username>', password:'<password>'});
+"
 ```
 
-### View logs for a specific pod
-```bash
-SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl logs <pod-name> -n <namespace> --tail=100
-```
+## Common kubectl Commands
 
-### Exec into a container via kubectl
-```bash
-SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl exec <pod-name> -n <namespace> -- <command>
-```
+Use the SSH pattern above with these commands. **Always use `sudo kubectl`** — the SSH user may not have direct access to the k3s kubeconfig.
 
-### Check resource usage
-```bash
-SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
-  echo "=== NODE RESOURCES ===" && kubectl top nodes &&
-  echo "=== POD RESOURCES ===" && kubectl top pods -A --sort-by=memory | head -20
-'
-```
-
-### Describe a failing pod
-```bash
-SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl describe pod <pod-name> -n <namespace>
-```
-
-### Restart a deployment
-```bash
-SSH_ASKPASS=/tmp/askpass.sh SSH_ASKPASS_REQUIRE=force ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> kubectl rollout restart deployment/<deployment-name> -n <namespace>
-```
+| Task | Command |
+|------|---------|
+| List all pods | `sudo kubectl get pods -A -o wide` |
+| Problem pods only | `sudo kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded` |
+| Pod logs | `sudo kubectl logs <pod-name> -n <namespace> --tail=100` |
+| Exec into container | `sudo kubectl exec <pod-name> -n <namespace> -- <command>` |
+| Node resources | `sudo kubectl top nodes` |
+| Pod resources | `sudo kubectl top pods -A --sort-by=memory \| head -20` |
+| Describe pod | `sudo kubectl describe pod <pod-name> -n <namespace>` |
+| Recent events | `sudo kubectl get events -A --sort-by=.lastTimestamp \| tail -30` |
+| Restart deployment | `sudo kubectl rollout restart deployment/<name> -n <namespace>` |
 
 ## Tips
 
-- **Do NOT use `sshpass`**: It is not available in the sandbox. Use `SSH_ASKPASS` as shown above.
-- **Create askpass script once**: Run the `echo ... > /tmp/askpass.sh` command once, then reuse it for all subsequent SSH calls in the same session.
-- **Combine commands**: Always batch related checks into a single SSH call using single quotes with `&&` to reduce round trips.
-- **Do NOT use `bash -c '...'`**: Pass commands directly in SSH quotes. Using `bash -c` causes quoting conflicts over SSH.
+- **Do NOT use `sshpass` or `SSH_ASKPASS`**: They are not available in the sandbox. Always use the `ssh2` Node.js approach shown above.
+- **Combine commands**: Batch related checks with `&&` in a single SSH call to reduce round trips.
 - **Use `-o wide`**: Adds node name and IP to pod listings, useful for debugging scheduling issues.
 - **Namespace matters**: Zeabur services typically run in non-default namespaces. Use `-A` (all namespaces) first to locate the right namespace, then scope subsequent commands with `-n <namespace>`.
-- **Read project docs first**: If a fix attempt fails, SSH into the container and check README or config files before blindly checking metrics: `kubectl exec <pod> -n <ns> -- cat /app/README.md`
+- **Read project docs first**: If a fix attempt fails, exec into the container and check README or config files before blindly checking metrics: `kubectl exec <pod> -n <ns> -- cat /app/README.md`
 - To find server IDs, use the `zeabur-server-list` skill. For simpler container commands that don't need server-level access, use the `zeabur-service-exec` skill instead.

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -30,8 +30,8 @@ npx zeabur@latest server list -i=false
 The sandbox has `ssh2` pre-installed. Use this Node.js one-liner to run commands via SSH:
 
 ```bash
-node -e "
-const {Client} = require('/home/vercel-sandbox/.global/node_modules/ssh2');
+NODE_PATH=/home/vercel-sandbox/.global/node_modules node -e "
+const {Client} = require('ssh2');
 const c = new Client();
 c.on('ready', () => {
   c.exec('<command>', (err, stream) => {
@@ -57,8 +57,8 @@ Replace `<ip>`, `<port>`, `<username>`, `<password>`, and `<command>` with actua
 Batch related checks into a single SSH call to minimize overhead:
 
 ```bash
-node -e "
-const {Client} = require('/home/vercel-sandbox/.global/node_modules/ssh2');
+NODE_PATH=/home/vercel-sandbox/.global/node_modules node -e "
+const {Client} = require('ssh2');
 const c = new Client();
 c.on('ready', () => {
   c.exec('echo \"=== PODS ===\" && kubectl get pods -A && echo \"=== SERVICES ===\" && kubectl get svc -A && echo \"=== EVENTS ===\" && kubectl get events -A --sort-by=.lastTimestamp | tail -20', (err, stream) => {
@@ -94,5 +94,5 @@ Use the SSH pattern above with these commands. **Always use `sudo kubectl`** —
 - **Combine commands**: Batch related checks with `&&` in a single SSH call to reduce round trips.
 - **Use `-o wide`**: Adds node name and IP to pod listings, useful for debugging scheduling issues.
 - **Namespace matters**: Zeabur services typically run in non-default namespaces. Use `-A` (all namespaces) first to locate the right namespace, then scope subsequent commands with `-n <namespace>`.
-- **Read project docs first**: If a fix attempt fails, exec into the container and check README or config files before blindly checking metrics: `kubectl exec <pod> -n <ns> -- cat /app/README.md`
+- **Read project docs first**: If a fix attempt fails, exec into the container and check README or config files before blindly checking metrics: `sudo kubectl exec <pod> -n <ns> -- cat /app/README.md`
 - To find server IDs, use the `zeabur-server-list` skill. For simpler container commands that don't need server-level access, use the `zeabur-service-exec` skill instead.

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -75,7 +75,7 @@ NODE_PATH=/home/vercel-sandbox/.global/node_modules node -e "
 const {Client} = require('ssh2');
 const c = new Client();
 c.on('ready', () => {
-  c.exec('echo \"=== PODS ===\" && sudo kubectl get pods -A && echo \"=== SERVICES ===\" && sudo kubectl get svc -A', (err, stream) => {
+  c.exec('echo \"=== PODS ===\" && sudo kubectl get pods -A && echo \"=== SERVICES ===\" && sudo kubectl get svc -A && echo \"=== EVENTS ===\" && sudo kubectl get events -A --sort-by=.lastTimestamp | tail -20', (err, stream) => {
     if (err) { console.error(err); process.exit(1); }
     let out = '';
     stream.on('data', d => out += d);

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -27,7 +27,25 @@ npx zeabur@latest server list -i=false
 
 ## Step 2: Run Commands via SSH
 
-The sandbox has `ssh2` pre-installed. Use this Node.js one-liner to run commands via SSH:
+Try `sshpass` first. If it's not available, fall back to the Node.js `ssh2` method.
+
+### Option A: sshpass (preferred if available)
+
+```bash
+# Single command
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> sudo kubectl get pods -A
+
+# Multiple commands in one SSH call
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
+  echo "=== PODS ===" && sudo kubectl get pods -A &&
+  echo "=== SERVICES ===" && sudo kubectl get svc -A &&
+  echo "=== EVENTS ===" && sudo kubectl get events -A --sort-by=.lastTimestamp | tail -20
+'
+```
+
+### Option B: Node.js ssh2 (when sshpass is unavailable)
+
+The Zeabur agent sandbox has `ssh2` pre-installed. Use this approach if `sshpass` is not available:
 
 ```bash
 NODE_PATH=/home/vercel-sandbox/.global/node_modules node -e "
@@ -50,18 +68,14 @@ c.on('ready', () => {
 "
 ```
 
-Replace `<ip>`, `<port>`, `<username>`, `<password>`, and `<command>` with actual values from Step 1.
-
-### Combine multiple commands (preferred)
-
-Batch related checks into a single SSH call to minimize overhead:
+For multiple commands, join them with `&&` in the command string:
 
 ```bash
 NODE_PATH=/home/vercel-sandbox/.global/node_modules node -e "
 const {Client} = require('ssh2');
 const c = new Client();
 c.on('ready', () => {
-  c.exec('echo \"=== PODS ===\" && kubectl get pods -A && echo \"=== SERVICES ===\" && kubectl get svc -A && echo \"=== EVENTS ===\" && kubectl get events -A --sort-by=.lastTimestamp | tail -20', (err, stream) => {
+  c.exec('echo \"=== PODS ===\" && sudo kubectl get pods -A && echo \"=== SERVICES ===\" && sudo kubectl get svc -A', (err, stream) => {
     if (err) { console.error(err); process.exit(1); }
     let out = '';
     stream.on('data', d => out += d);
@@ -74,7 +88,7 @@ c.on('ready', () => {
 
 ## Common kubectl Commands
 
-Use the SSH pattern above with these commands. **Always use `sudo kubectl`** — the SSH user may not have direct access to the k3s kubeconfig.
+**Always use `sudo kubectl`** — the SSH user may not have direct access to the k3s kubeconfig.
 
 | Task | Command |
 |------|---------|
@@ -90,8 +104,9 @@ Use the SSH pattern above with these commands. **Always use `sudo kubectl`** —
 
 ## Tips
 
-- **Do NOT use `sshpass` or `SSH_ASKPASS`**: They are not available in the sandbox. Always use the `ssh2` Node.js approach shown above.
+- **Try `sshpass` first**: Run `which sshpass` to check. If available, use Option A (simpler). If not, use Option B (Node.js ssh2).
 - **Combine commands**: Batch related checks with `&&` in a single SSH call to reduce round trips.
+- **Do NOT use `bash -c '...'` over SSH**: Pass commands directly in SSH quotes. Using `bash -c` causes quoting conflicts.
 - **Use `-o wide`**: Adds node name and IP to pod listings, useful for debugging scheduling issues.
 - **Namespace matters**: Zeabur services typically run in non-default namespaces. Use `-A` (all namespaces) first to locate the right namespace, then scope subsequent commands with `-n <namespace>`.
 - **Read project docs first**: If a fix attempt fails, exec into the container and check README or config files before blindly checking metrics: `sudo kubectl exec <pod> -n <ns> -- cat /app/README.md`


### PR DESCRIPTION
## Summary
- Replace `sshpass`/`SSH_ASKPASS` patterns with Node.js `ssh2` library approach
- `ssh2` is pre-installed in sandbox via companion PR zeabur/zeabur.com#643
- Add `sudo kubectl` guidance — SSH user may not have direct k3s kubeconfig access
- Simplify skill to use a table of common kubectl commands instead of repeating full SSH boilerplate

## Why
Vercel Sandbox doesn't have `sshpass`, `apt-get`, `expect`, or working `SSH_ASKPASS`. The `ssh2` Node.js library is the only reliable way to do password-based SSH.

## Test plan
- [x] `ssh2` connects and runs `k3s --version` — returns `v1.32.4+k3s1`
- [x] `sudo kubectl top nodes` — returns node metrics
- [x] `sudo kubectl get pods -A` — lists all pods
- [x] Combined commands pattern works
- [x] Non-root user (`ubuntu`) confirmed to need `sudo` for kubectl

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782325275&installation_id=128583772&pr_number=65&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F65&signature=419b2323b64e59e16f5715bda4c5dc8874a5a64366f12420de1e1c01946b8d77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->