### PR TITLE
fix: default to ssh2 instead of trying sshpass first

### DIFF
--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -27,9 +27,9 @@ npx zeabur@latest server list -i=false
 
 ## Step 2: Run Commands via SSH
 
-Try `sshpass` first. If it's not available, fall back to the Node.js `ssh2` method.
+Use the Node.js `ssh2` method by default. Use `sshpass` only when its availability is already known.
 
-### Option A: sshpass (preferred if available)
+### Option A: sshpass (only if already known to be available)
 
 ```bash
 # Single command
@@ -43,9 +43,9 @@ sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip
 '
 ```
 
-### Option B: Node.js ssh2 (when sshpass is unavailable)
+### Option B: Node.js ssh2 (default)
 
-The Zeabur agent sandbox has `ssh2` pre-installed. Use this approach if `sshpass` is not available:
+The Zeabur agent sandbox has `ssh2` pre-installed. Use this approach by default:
 
 ```bash
 NODE_PATH=/home/vercel-sandbox/.global/node_modules node -e "

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -104,7 +104,7 @@ c.on('ready', () => {
 
 ## Tips
 
-- **Try `sshpass` first**: Run `which sshpass` to check. If available, use Option A (simpler). If not, use Option B (Node.js ssh2).
+- **Use Node.js ssh2 by default (Option B)**: Only use `sshpass` (Option A) if you already know it's available. Do NOT run `which sshpass` to check — it wastes a step in environments where it's never installed.
 - **Combine commands**: Batch related checks with `&&` in a single SSH call to reduce round trips.
 - **Do NOT use `bash -c '...'` over SSH**: Pass commands directly in SSH quotes. Using `bash -c` causes quoting conflicts.
 - **Use `-o wide`**: Adds node name and IP to pod listings, useful for debugging scheduling issues.


### PR DESCRIPTION
## Summary
- Change Tips to recommend ssh2 (Option B) by default instead of trying `sshpass` first
- Avoids wasting a step running `which sshpass` in sandbox environments where it's never available

## Test plan
- [ ] Agent uses ssh2 directly without first checking for sshpass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782331052&installation_id=128583772&pr_number=66&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F66&signature=13db1a4507fd41c5528609f1172f88b0625c58e623c16df30ac91c40352b83e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->