### PR TITLE
fix: dynamic NODE_PATH for ssh2 on Zeabur sandbox

### DIFF
--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -48,7 +48,7 @@ sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip
 The Zeabur agent sandbox has `ssh2` pre-installed. Use this approach by default:
 
 ```bash
-NODE_PATH=/home/vercel-sandbox/.global/node_modules node -e "
+NODE_PATH=$([ -d /root/.global/node_modules ] && echo /root/.global/node_modules || echo /home/vercel-sandbox/.global/node_modules) node -e "
 const {Client} = require('ssh2');
 const c = new Client();
 c.on('ready', () => {
@@ -71,7 +71,7 @@ c.on('ready', () => {
 For multiple commands, join them with `&&` in the command string:
 
 ```bash
-NODE_PATH=/home/vercel-sandbox/.global/node_modules node -e "
+NODE_PATH=$([ -d /root/.global/node_modules ] && echo /root/.global/node_modules || echo /home/vercel-sandbox/.global/node_modules) node -e "
 const {Client} = require('ssh2');
 const c = new Client();
 c.on('ready', () => {


### PR DESCRIPTION
## Summary
- ssh2 is installed at `/root/.global` on Zeabur sandbox but `/home/vercel-sandbox/.global` on Vercel sandbox
- SKILL.md had the Vercel path hardcoded, causing `require('ssh2')` to fail on Zeabur sandbox and the agent to fall back to sshpass
- Changed NODE_PATH to auto-detect: checks `/root/.global/node_modules` first, falls back to Vercel path

## Test plan
- [ ] Test SSH skill on Zeabur sandbox (zeabur.dev) — should use ssh2 instead of sshpass
- [ ] Test SSH skill on Vercel sandbox (zeabur.com) — should still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784104574&installation_id=128583772&pr_number=69&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F69&signature=8c3aa9ebd0e02c126bcc4321282d8ca00739f04389eb693dd94c19a301dbed43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SSH command examples with improved NODE_PATH handling. The system now dynamically prioritizes `/root/.global/node_modules` when available and falls back to `/home/vercel-sandbox/.global/node_modules` as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->