### PR TITLE
feat: add Codex plugin marketplace manifest (fix codex plugin add)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "zeabur",
+  "interface": {
+    "displayName": "Zeabur"
+  },
+  "plugins": [
+    {
+      "name": "zeabur",
+      "source": { "source": "local", "path": "./plugins/zeabur" },
+      "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.github/workflows/codex-plugin-sync.yml
+++ b/.github/workflows/codex-plugin-sync.yml
@@ -11,8 +11,12 @@ on:
 jobs:
   check-sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
@@ -20,7 +24,7 @@ jobs:
         run: node scripts/sync-codex-plugin.mjs
       - name: Verify it matches the committed output
         run: |
-          if ! git diff --exit-code -- plugins/zeabur; then
+          if [[ -n "$(git status --porcelain=v1 --untracked-files=all -- plugins/zeabur)" ]]; then
             echo "::error::plugins/zeabur is out of sync with root skills/. Run: node scripts/sync-codex-plugin.mjs and commit the result."
             exit 1
           fi

--- a/.github/workflows/codex-plugin-sync.yml
+++ b/.github/workflows/codex-plugin-sync.yml
@@ -1,0 +1,26 @@
+name: codex-plugin-sync
+
+# Ensures plugins/zeabur/ (the generated Codex plugin) stays in sync with the
+# canonical root skills/. If someone edits a skill without re-running the sync
+# script, this fails so the drift is caught before merge.
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Regenerate Codex plugin
+        run: node scripts/sync-codex-plugin.mjs
+      - name: Verify it matches the committed output
+        run: |
+          if ! git diff --exit-code -- plugins/zeabur; then
+            echo "::error::plugins/zeabur is out of sync with root skills/. Run: node scripts/sync-codex-plugin.mjs and commit the result."
+            exit 1
+          fi

--- a/.github/workflows/codex-plugin-sync.yml
+++ b/.github/workflows/codex-plugin-sync.yml
@@ -12,8 +12,8 @@ jobs:
   check-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
       - name: Regenerate Codex plugin

--- a/plugins/zeabur/.codex-plugin/plugin.json
+++ b/plugins/zeabur/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "zeabur",
+  "version": "1.18.0",
+  "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
+  "author": {
+    "name": "Zeabur",
+    "url": "https://zeabur.com"
+  },
+  "repository": "https://github.com/zeabur/zeabur-claude-plugin",
+  "license": "MIT",
+  "keywords": [
+    "zeabur",
+    "deployment",
+    "cli",
+    "templates",
+    "devops",
+    "cloud"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Zeabur",
+    "shortDescription": "Deploy and manage apps on Zeabur",
+    "longDescription": "CLI-based skills for deploying, managing services, renting servers, registering domains, and troubleshooting on Zeabur. Works with both Claude Code and OpenAI Codex.",
+    "developerName": "Zeabur",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://zeabur.com",
+    "defaultPrompt": [
+      "Deploy this project to Zeabur",
+      "List my Zeabur servers",
+      "Rent a new server on Hetzner"
+    ]
+  }
+}

--- a/plugins/zeabur/skills/zeabur-ai-hub/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-ai-hub/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: zeabur-ai-hub
+description: Use when managing AI Hub account, API keys, balance, usage, or API endpoints. Use when user says "AI Hub", "add AI credits", "create API key", "check AI usage", "auto-recharge", "AI Hub endpoint", "AI Hub base URL", "how to use AI Hub API", "LLM API", "AI API", "OpenAI compatible", "Anthropic API", "GPT", "Claude", "Gemini", "DeepSeek", or "Grok" in the context of Zeabur.
+---
+
+# Zeabur AI Hub Management
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## API Endpoints
+
+AI Hub is OpenAI-compatible. Users can pick the region closest to them:
+
+| Region | Endpoint |
+|--------|----------|
+| Tokyo, Japan (HND1) | `https://hnd1.aihub.zeabur.ai/` |
+| San Francisco, USA (SFO1) | `https://sfo1.aihub.zeabur.ai/` |
+
+### Quick Start (OpenAI SDK)
+
+**JavaScript / TypeScript:**
+
+```javascript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+    baseURL: "https://hnd1.aihub.zeabur.ai/v1",  // or sfo1
+    apiKey: "sk-xxxxxxxxxxxxxxxx",              // from AI Hub dashboard
+});
+
+const stream = await client.chat.completions.create({
+    model: "claude-sonnet-4-5",  // any model available on AI Hub
+    messages: [{ role: "user", content: "Hello!" }],
+    stream: true,
+});
+```
+
+**Python:**
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://hnd1.aihub.zeabur.ai/v1",  # or sfo1
+    api_key="sk-xxxxxxxxxxxxxxxx",              # from AI Hub dashboard
+)
+
+stream = client.chat.completions.create(
+    model="claude-sonnet-4-5",
+    messages=[{"role": "user", "content": "Hello!"}],
+    stream=True,
+)
+```
+
+**curl:**
+
+```bash
+curl https://hnd1.aihub.zeabur.ai/v1/chat/completions \
+  -H "Authorization: Bearer sk-xxxxxxxxxxxxxxxx" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"claude-sonnet-4-5","messages":[{"role":"user","content":"Hello!"}]}'
+```
+
+### Other SDK Compatibility
+
+- **Anthropic SDK**: set `baseURL` / `base_url` to the endpoint above
+- **Vercel AI SDK (`@ai-sdk/openai`)**: set `baseURL` to the endpoint above
+
+### Environment Variables
+
+When users deploy apps on Zeabur, suggest setting:
+
+```bash
+OPENAI_API_KEY=sk-xxxxxxxxxxxxxxxx
+OPENAI_BASE_URL=https://hnd1.aihub.zeabur.ai/v1
+```
+
+Most OpenAI-compatible libraries will pick these up automatically.
+
+## Check AI Hub Status
+
+```bash
+npx zeabur@latest ai-hub status -i=false
+npx zeabur@latest ai-hub status -i=false --json
+```
+
+Shows tenant balance, API keys, and auto-recharge settings.
+
+## API Key Management
+
+```bash
+# List all keys
+npx zeabur@latest ai-hub keys list -i=false
+npx zeabur@latest ai-hub keys ls -i=false --json
+
+# Create a new key (optional alias)
+npx zeabur@latest ai-hub keys create --alias "my-app" -i=false
+
+# Delete a key
+npx zeabur@latest ai-hub keys delete --key-id <key-id> -i=false
+```
+
+**The API key is only shown once at creation time.** Make sure the user saves it immediately.
+
+## Add Balance
+
+```bash
+# Add $10 to AI Hub balance
+npx zeabur@latest ai-hub add-balance --amount 10 -i=false
+```
+
+- Amount is in **whole dollars** (integer).
+- Deducts from Zeabur account credits. If insufficient credits and no linked card, a checkout page opens in the browser automatically.
+
+## Check Usage
+
+```bash
+# Current month usage
+npx zeabur@latest ai-hub usage -i=false
+
+# Specific month
+npx zeabur@latest ai-hub usage --month 2026-03 -i=false
+npx zeabur@latest ai-hub usage --month 2026-03 -i=false --json
+```
+
+Shows total spend and per-model cost breakdown. `--month` must be in `YYYY-MM` format.
+
+## Auto-Recharge Settings
+
+```bash
+# Enable: recharge $20 when balance drops below $5
+npx zeabur@latest ai-hub auto-recharge --threshold 5 --amount 20 -i=false
+
+# Disable auto-recharge
+npx zeabur@latest ai-hub auto-recharge --threshold 0 --amount 0 -i=false
+```
+
+Both `--threshold` and `--amount` are in whole dollars.

--- a/plugins/zeabur/skills/zeabur-auth/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-auth/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: zeabur-auth
+description: Use when logging in, logging out, or checking Zeabur auth status. Use when user says "login", "log in", "登入", "logout", "log out", "登出", "auth status", "am I logged in", or "who am I".
+---
+
+# Zeabur Authentication
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Login
+
+Run the login command directly — the CLI will automatically open the browser for the user:
+
+```bash
+npx zeabur@latest auth login
+```
+
+Login with a token (for CI/CD or headless environments):
+
+```bash
+npx zeabur@latest auth login --token <token> -i=false
+```
+
+## Check Login Status
+
+```bash
+npx zeabur@latest auth status -i=false
+```
+
+## Logout
+
+```bash
+npx zeabur@latest auth logout -i=false
+```
+
+## Tips
+
+- **Never ask the user to run the login command themselves** — run it directly and let the CLI auto-open the browser
+- Token-based login is useful for CI/CD or headless environments
+- Run `auth status` first to check if the user is already logged in before suggesting login

--- a/plugins/zeabur/skills/zeabur-database/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-database/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: zeabur-database
+description: Use when deploying a database to Zeabur. Use when user needs MySQL, PostgreSQL, MongoDB, or Redis. Use when user says "I need a database", "add database", "deploy postgres", "set up MySQL", "add Redis", "add MongoDB", or "connect to database". Also use when user mentions data persistence issues like "data lost after restart", "data not saved", "data disappears", "need persistent storage for data", or "how to persist data". Also use when integrating a database with an existing service.
+---
+
+# Zeabur Database Deployment & Integration
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Deploy a Database
+
+> **Before deploying, you MUST load the `zeabur-template` skill first** to understand what Zeabur templates are, how they work, and how to deploy them. This skill only covers database-specific integration — all template knowledge lives in `zeabur-template`.
+
+Search for a database template:
+
+```bash
+npx zeabur@latest template search postgresql -i=false --json
+```
+
+Pick the template with the highest deployment count. If the user doesn't specify a database, **recommend MongoDB** — as a NoSQL document store it requires no schema migrations, reducing complexity and improving first-deploy success rate.
+
+---
+
+## After Deployment: How to Connect
+
+For any database, you need two pieces of information: **how to connect** (hostname + port) and **how to authenticate** (username + password + database name).
+
+### How to connect — `service network`
+
+```bash
+npx zeabur@latest service network --id <database-service-id> -i=false
+```
+
+This shows:
+- **Private Networking** — internal `hostname:port` for inter-service access (e.g., `mysql.zeabur.internal:3306`)
+- **Public Networking** — external `host:port` for connecting from your local machine (via port forwarding)
+
+### How to authenticate — `variable list`
+
+```bash
+npx zeabur@latest variable list --id <database-service-id> -i=false
+```
+
+This lists all the credentials (username, password, database name, etc.) for the database service.
+
+---
+
+## PostgreSQL
+
+### Credentials (from `variable list`)
+
+| Variable | Description |
+|----------|-------------|
+| `POSTGRES_USERNAME` | Username (default: `root`) |
+| `POSTGRES_PASSWORD` | Password (auto-generated) |
+| `POSTGRES_DATABASE` | Database name (default: `zeabur`) |
+
+### Connect from local machine
+
+```bash
+psql "postgresql://POSTGRES_USERNAME:POSTGRES_PASSWORD@PUBLIC_HOST:PUBLIC_PORT/POSTGRES_DATABASE"
+```
+
+### Connect from app (same project)
+
+Set env vars on your app service using the values from `variable list`:
+
+```
+DB_HOST=${POSTGRES_HOST}
+DB_PORT=${POSTGRES_PORT}
+DB_USERNAME=${POSTGRES_USERNAME}
+DB_PASSWORD=${POSTGRES_PASSWORD}
+DB_DATABASE=${POSTGRES_DATABASE}
+```
+
+Or construct a connection string: `postgresql://${POSTGRES_USERNAME}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}`
+
+---
+
+## MySQL
+
+### Credentials (from `variable list`)
+
+| Variable | Description |
+|----------|-------------|
+| `MYSQL_USERNAME` | Username (default: `root`) |
+| `MYSQL_PASSWORD` | Password (auto-generated) |
+| `MYSQL_DATABASE` | Database name (default: `zeabur`) |
+
+### Connect from local machine
+
+```bash
+mysql -h PUBLIC_HOST -P PUBLIC_PORT -u MYSQL_USERNAME -p MYSQL_DATABASE
+```
+
+### Connect from app (same project)
+
+Set env vars on your app service using the values from `variable list`:
+
+```
+DB_HOST=${MYSQL_HOST}
+DB_PORT=${MYSQL_PORT}
+DB_USERNAME=${MYSQL_USERNAME}
+DB_PASSWORD=${MYSQL_PASSWORD}
+DB_DATABASE=${MYSQL_DATABASE}
+```
+
+Or construct a connection string: `mysql://${MYSQL_USERNAME}:${MYSQL_PASSWORD}@${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}`
+
+---
+
+## MongoDB
+
+### Credentials (from `variable list`)
+
+| Variable | Description |
+|----------|-------------|
+| `MONGO_USERNAME` | Username (default: `mongo`) |
+| `MONGO_PASSWORD` | Password (auto-generated) |
+
+### Connect from local machine
+
+```bash
+mongosh "mongodb://MONGO_USERNAME:MONGO_PASSWORD@PUBLIC_HOST:PUBLIC_PORT"
+```
+
+### Connect from app (same project)
+
+Construct a connection string: `mongodb://${MONGO_USERNAME}:${MONGO_PASSWORD}@${MONGO_HOST}:${MONGO_PORT}`
+
+Works with Mongoose, PyMongo, and any MongoDB driver.
+
+---
+
+## Redis
+
+### Credentials (from `variable list`)
+
+| Variable | Description |
+|----------|-------------|
+| `REDIS_PASSWORD` | Password (auto-generated) |
+
+> Redis has no username or database name by default.
+
+### Connect from local machine
+
+```bash
+redis-cli -h PUBLIC_HOST -p PUBLIC_PORT -a REDIS_PASSWORD
+```
+
+### Connect from app (same project)
+
+Construct a connection string: `redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}`
+
+Works with ioredis, redis-py, go-redis, and any Redis client.
+
+---
+
+## Caveats
+
+1. **Variable references** — Zeabur uses a flat namespace. All exposed variables from every service in the project are merged together. Your app references them directly by name (e.g., `${POSTGRES_HOST}`), no prefix needed. Set them via the **Zeabur Dashboard** — the CLI has a known bug with `${}` expansion.
+2. **Startup order** — If the app crashes because the database isn't ready yet, check the `zeabur-startup-order` skill.
+3. **Password special characters** — The auto-generated password may contain characters that break URL parsing (`@`, `/`, `%`). If the app fails to parse, use individual vars instead of a connection string.
+4. **Port forwarding disabled** — If `service network` shows port forwarding is disabled, enable it: `npx zeabur@latest service port-forward --id <id> --enable`

--- a/plugins/zeabur/skills/zeabur-deploy/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-deploy/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: zeabur-deploy
+description: Use when deploying a local project or codebase to Zeabur. Use when the user says "deploy this", "deploy to Zeabur", "deploy from GitHub", "search my repos", or "find my repository". Default to direct deploy unless the user explicitly asks for Git-based deployment.
+---
+
+# Zeabur Deploy
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Prerequisites — Identify the Target Project
+
+Before using this skill, you must first determine which Zeabur project to deploy to. If neither the conversation history nor project files mention a project, run:
+
+```bash
+npx zeabur@latest project list -i=false --json
+```
+
+- When projects exist, ask the user which one to use.
+- If the list is empty, or the user wants to create a new project, **you MUST invoke the `zeabur-project-create` skill**. Do NOT run `project create` CLI commands directly — the skill handles region selection via server list, which is required.
+
+**Do not proceed with deployment until the target project is confirmed.**
+
+### Deploying to a Specific Dedicated Server
+
+If the user asks to deploy to a specific **server** (e.g. "deploy to my AWS Tokyo server"), do **NOT** SSH into the server. Zeabur dedicated servers are managed via the platform — you deploy services through the Zeabur CLI, not by manually placing files on the machine.
+
+To find the project bound to a server:
+
+1. Get the server ID from `npx zeabur@latest server list -i=false` (or from conversation context).
+2. In the `project list --json` output, look for a project whose `Region.ID` matches `server-<server-id>`.
+3. If a matching project exists, use its project ID to deploy.
+4. If no matching project exists, **invoke the `zeabur-project-create` skill** to create one on that server.
+
+## Choosing a Deploy Method
+
+Zeabur supports two ways to deploy a project:
+
+| Method | When to use |
+|--------|-------------|
+| **Direct deploy** (default) | User says "deploy this project/website/app". No Git repo required. Fast and simple. |
+| **Git deploy** | User explicitly asks to deploy via Git/GitHub, or wants CI/CD with automatic redeploy on push. |
+
+**Default to direct deploy** unless the user specifically requests Git-based deployment.
+
+## Direct Deploy (Default)
+
+Deploy the current local directory to Zeabur with one command.
+
+### Flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--project-id` | Yes (non-interactive) | Project ID to deploy on |
+| `--json` | Recommended | Output in JSON format |
+| `--name` | No | Service name (defaults to directory name) |
+| `--service-id` | No | Service ID to redeploy on (omit to create new service) |
+| `--environment-id` | No | Environment ID (defaults to first environment) |
+
+> **Note:** Do NOT use `--create`, `-r`, or `--region` flags with deploy commands. If the user needs to create a new project or select a region, use the `zeabur-project-create` skill first.
+
+### First Deploy
+
+When deploying for the first time, omit `--service-id` — a new service is created automatically:
+
+```bash
+npx zeabur@latest deploy --project-id <project-id> --json
+```
+
+The response includes a `service_id`. **You MUST save this `service_id` for all subsequent deploys.** Write it to the current project's `CLAUDE.md` immediately:
+
+```markdown
+## Zeabur Deployment
+- Project ID: <project-id>
+- Service ID: <service-id>
+```
+
+### Redeploy (Update Existing Service)
+
+**IMPORTANT: When redeploying code changes, you MUST pass `--service-id` to update the existing service. Omitting `--service-id` creates a NEW duplicate service every time.**
+
+```bash
+npx zeabur@latest deploy --project-id <project-id> --service-id <service-id> --json
+```
+
+> **Do NOT use this flow for version upgrades / downgrades of prebuilt or marketplace services** (e.g. "upgrade PostgreSQL to 16", "downgrade n8n to 1.2"). That is a version switch, not a code redeploy — use the **`zeabur-update-service`** skill's tag update instead. Redeploying in place of a tag change can orphan or wipe the service's mounted disk.
+
+If no project exists yet, **invoke the `zeabur-project-create` skill** (do not run CLI commands directly).
+
+## Git Deploy (On User Request)
+
+If the user explicitly wants Git-based deployment (e.g. for CI/CD, auto-redeploy on push):
+
+1. First, ensure the code is pushed to a GitHub repository.
+2. Deploy via CLI:
+
+```bash
+# Non-interactive mode — required parameters only
+npx zeabur@latest service deploy --json -i=false \
+  --project-id <project-id> \
+  --template GIT \
+  --repo-id <repo-id> \
+  --branch-name <branch>
+
+# With optional service name
+npx zeabur@latest service deploy --json -i=false \
+  --project-id <project-id> \
+  --template GIT \
+  --repo-id <repo-id> \
+  --branch-name <branch> \
+  --name "<service-name>"
+```
+
+### Git Deploy Flags
+
+| Flag | Required | Description |
+|------|----------|-------------|
+| `--template GIT` | Yes | Specifies Git-based deployment |
+| `--project-id` | Non-interactive | Project ID (interactive mode will prompt) |
+| `--repo-id` | Non-interactive | GitHub repository ID |
+| `--branch-name` | Non-interactive | Git branch to deploy from |
+| `--name` | No | Service name (defaults to repo name) |
+| `--keyword` | No | Keyword to search GitHub repos (interactive mode) |
+
+### Git Deploy Workflow
+
+**Git deploy workflow:**
+
+```bash
+# 1. Search for the user's GitHub repo
+npx zeabur@latest service search-repo <keyword> --json -i=false
+# Returns: [{"Name":"my-app","Owner":"user","URL":"...","ID":12345}, ...]
+# If multiple results are returned, ask the user which repo to deploy.
+# The agent (not the CLI) is responsible for disambiguation.
+
+# 2. Deploy from GitHub using the repo ID from search results
+npx zeabur@latest service deploy --json -i=false \
+  --project-id $PROJECT_ID \
+  --template GIT \
+  --repo-id <repo-id> \
+  --branch-name main
+```
+
+After deployment, Zeabur will auto-redeploy on every push to the selected branch.
+
+Only guide the user through this flow when they specifically ask for Git-based deployment.
+
+## Tips
+
+- Direct deploy only requires `--project-id` — a new service is created automatically. No Git history or GitHub account required.
+- For static sites, Zeabur auto-detects and serves them correctly.
+- **Always save both Project ID and Service ID** after first deploy. This prevents duplicate services on redeploy.
+- After deployment, use the `zeabur-deployment-logs` skill to check build and runtime logs.

--- a/plugins/zeabur/skills/zeabur-deployment-logs/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-deployment-logs/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: zeabur-deployment-logs
+description: Use when viewing service runtime or build logs. Use when user says "show logs", "why did deploy fail", "check build output", or "debug runtime error".
+---
+
+# Zeabur Deployment Logs
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Workflow
+
+```bash
+# 1. Get service ID (use the `zeabur-service-list` skill)
+npx zeabur@latest service list --project-id <project-id> -i=false
+
+# 2. View runtime logs
+npx zeabur@latest deployment log --service-id <service-id> -t runtime -i=false 2>&1 | tail -50
+```
+
+## Log Types
+
+```bash
+# Runtime logs (CLI auto-resolves the latest deployment if needed)
+npx zeabur@latest deployment log --service-id <id> -t runtime -i=false
+
+# Runtime logs for a specific deployment
+npx zeabur@latest deployment log --service-id <id> --deployment-id <deployment-id> -t runtime -i=false
+
+# Build logs (CLI auto-resolves the latest deployment if needed)
+npx zeabur@latest deployment log --service-id <id> -t build -i=false
+
+# Build logs for a specific deployment
+npx zeabur@latest deployment log --deployment-id <deployment-id> -t build -i=false
+
+# Watch logs (live tail)
+npx zeabur@latest deployment log --service-id <id> -w -i=false
+```
+
+## DeploymentID Behavior
+
+The CLI automatically resolves the latest deployment when `--deployment-id` is not provided:
+
+| Scenario | What happens |
+|----------|-------------|
+| Git/Upload service, no `--deployment-id` | CLI auto-resolves latest deployment → logs returned |
+| Pure image service (e.g. Docker image), runtime log | No deployment exists → falls back to prebuilt query → logs returned |
+| Pure image service, build log | No deployment exists → returns error (image services have no build logs) |
+| Explicit `--deployment-id` provided | Uses the provided ID directly, no auto-resolution |
+
+Use `--deployment-id` when you need logs from a **specific** deployment (not the latest). List deployments with:
+
+```bash
+npx zeabur@latest deployment list --service-id <service-id> -i=false
+```
+
+## Tips
+
+| Tip | Details |
+|-----|---------|
+| Use `tail -50` | Logs can be verbose, pipe to tail for recent entries |
+| Use `grep` to filter | `... 2>&1 | grep -i "error\|started\|ready"` |
+| Note singular | `deployment log` not `deployment logs` |
+| Check service status | Look for `SERVER STARTED`, `Ready`, `listening` |
+
+After diagnosing issues from logs, use the `zeabur-restart` skill to restart the service if needed.

--- a/plugins/zeabur/skills/zeabur-dockerfile/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-dockerfile/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: zeabur-dockerfile
+description: Use when generating a Dockerfile for deploying a project to Zeabur. Use when the user needs help writing a Dockerfile for Node.js, Python, Go, Rust, PHP, Ruby, Java, .NET, or Elixir projects. Use when troubleshooting Dockerfile build failures on Zeabur.
+---
+
+# Zeabur Dockerfile Generation
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+When deploying source code to Zeabur, you must generate a Dockerfile. This skill covers how to analyze a project and produce a correct, deployable Dockerfile.
+
+## Prerequisites
+
+Before generating a Dockerfile, read the key project files:
+
+| Language | Files to read |
+|----------|---------------|
+| Node.js | `package.json`, lockfile (`package-lock.json` / `yarn.lock` / `pnpm-lock.yaml`) |
+| Python | `requirements.txt`, `Pipfile`, `pyproject.toml` |
+| Go | `go.mod` |
+| Rust | `Cargo.toml` |
+| PHP | `composer.json` |
+| Ruby | `Gemfile` |
+| Java | `pom.xml`, `build.gradle` |
+| .NET | `*.csproj`, `*.sln` |
+| Elixir | `mix.exs` |
+
+Also check for:
+- Existing `Dockerfile` or `docker-compose.yml`
+- Build config (`vite.config.js`, `webpack.config.js`, `next.config.js`, etc.)
+- `.env.example` for required environment variables
+
+**What NOT to read** — skip these to save tokens:
+- HTML files — static assets, never affect deployment logic
+- Lockfile contents — only check which lockfile *exists* (to determine package manager). Do NOT parse the contents.
+- Markdown files — documentation only, never influences Dockerfile decisions
+
+## Workflow
+
+### 1. Analyze the Project
+
+From the prerequisite files, determine:
+1. Programming language and version
+2. Framework (if any)
+3. Package manager
+4. Build command
+5. Start command
+6. Port the app listens on
+7. Static site vs server-side app
+
+### 2. Generate the Dockerfile
+
+#### General Rules
+
+- No comments in the Dockerfile
+- No `ENV` or `ARG` instructions (unless required by the framework — see language-specific sections)
+- Add `LABEL "language"="<lang>"` — possible values: `nodejs`, `python`, `go`, `static`, `ruby`, `java`, `php`, `rust`, `dotnet`, `elixir`, `swift`, `bun`
+- Add `LABEL "framework"="<framework>"` only for **actual web frameworks** (see list below)
+- Always `COPY . .` before running any install/build commands
+- Set `WORKDIR /src` unless the user specifies otherwise
+- Add `EXPOSE` for the port the app listens on
+- Do not use multi-stage builds unless the build image differs from the runtime image (e.g., build with Node.js, serve with `zeabur/caddy-static`)
+
+#### Framework vs Package — Only These Get a Framework Label
+
+**Frameworks** (use `LABEL "framework"="..."`):
+`vite`, `create-react-app`, `next.js`, `remix`, `nuxt.js`, `umi`, `nest.js`, `hexo`, `vitepress`, `astro`, `sli.dev`, `docusaurus`, `nitropack`, `hono`, `medusa`, `svelte`, `flask`, `django`, `fastapi`, `spring-boot`, `laravel`, `thinkphp`, `rails`, `aspnet`, `blazorwasm`, `elysia`, `baojs`
+
+**Never label as framework** (these are packages/libraries):
+- Python: gradio, pandas, numpy, requests, matplotlib, scikit-learn, tensorflow, pytorch, opencv, pillow, beautifulsoup4, selenium
+- Node.js: express, koa, hapi, fastify, socket.io, moment, lodash, axios
+- Other: bootstrap, jquery, chart.js, three.js, d3.js
+
+> If unsure whether something is a framework or package, do NOT add the framework label.
+
+#### Static Sites — `zeabur/caddy-static`
+
+For **pure static websites** (Vite, Astro static, Docusaurus, plain HTML), use `zeabur/caddy-static`:
+
+```dockerfile
+FROM node:22-slim AS build
+LABEL "language"="nodejs"
+LABEL "framework"="vite"
+WORKDIR /src
+COPY . .
+RUN npm install
+RUN npm run build
+
+FROM zeabur/caddy-static
+COPY --from=build /src/dist /usr/share/caddy
+```
+
+Rules for `zeabur/caddy-static`:
+- Copy build output to `/usr/share/caddy`
+- Do NOT add `CMD` or `ENTRYPOINT` — the image handles it
+- It listens on port `8080`
+- Only use for truly static sites. Do NOT use for SSR frameworks (Next.js, Nuxt.js, SvelteKit, etc.)
+- If building with Node.js then serving as static, set `LABEL "language"="nodejs"` (not `"static"`)
+
+#### Node.js
+
+- Default base image: `node:22-slim`
+- Determine package manager by lockfile presence:
+
+| Lockfile | Package manager | Install command |
+|----------|-----------------|-----------------|
+| `package-lock.json` | npm | `npm install` |
+| `yarn.lock` | yarn | `yarn install` |
+| `pnpm-lock.yaml` | pnpm | `RUN npm install -g pnpm && pnpm install` |
+
+- When using `npm`, use `npm install`. Do NOT use `npm ci` or flags like `--only=production`, `--omit=dev`, `--frozen-lockfile`.
+- For Vite static sites (React, Vue static builds), use `zeabur/caddy-static` to serve.
+- For Vite with SSR frameworks (SvelteKit), use Node.js runtime.
+
+**Next.js** — Zeabur injects `PORT=8080` into the container, so Next.js production mode listens on 8080 by default. No extra config needed.
+
+```dockerfile
+FROM node:22-slim
+LABEL "language"="nodejs"
+LABEL "framework"="next.js"
+WORKDIR /src
+COPY . .
+RUN npm install
+RUN npm run build
+EXPOSE 8080
+CMD ["npm", "start"]
+```
+
+**Svelte / SvelteKit** — Use `node:22` (not alpine, not slim). Set `ENV PORT=8080`. Single-stage build — do NOT use `zeabur/caddy-static`. Do NOT use `cross-env ADAPTER=static` or adapter-specific build commands.
+
+```dockerfile
+FROM node:22
+LABEL "language"="nodejs"
+LABEL "framework"="svelte"
+ENV PORT=8080
+WORKDIR /src
+RUN npm install -g pnpm@9
+COPY . .
+RUN pnpm install
+RUN pnpm build
+EXPOSE 8080
+CMD ["pnpm", "start"]
+```
+
+#### Python
+
+- Default base image: `python:3.10`
+
+**Flask** — Find the WSGI entry first. For example, if `main.py` contains `app = Flask(__name__)`, the entry is `main:app`.
+
+```dockerfile
+FROM python:3.10
+LABEL "language"="python"
+LABEL "framework"="flask"
+WORKDIR /src
+COPY . .
+RUN pip install -r requirements.txt gunicorn
+EXPOSE 8080
+CMD ["gunicorn", "--bind", "0.0.0.0:8080", "main:app"]
+```
+
+**FastAPI** — Choose the start method based on what exists:
+1. If `fastapi-cli` is in `requirements.txt` → `fastapi run`
+2. If `if __name__ == "__main__":` exists in a `.py` file → `python <file>.py`
+3. Otherwise → `uvicorn main:app --host 0.0.0.0 --port 8080` (install `uvicorn` if missing)
+
+```dockerfile
+FROM python:3.10
+LABEL "language"="python"
+LABEL "framework"="fastapi"
+WORKDIR /src
+COPY . .
+RUN pip install -r requirements.txt
+EXPOSE 8080
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+```
+
+**Generic Python** — If WSGI might be applicable, use `gunicorn`. If unsure, just use `python <file>.py`.
+
+#### Go
+
+```dockerfile
+FROM golang:1.23 AS build
+WORKDIR /src
+COPY . .
+RUN go build -o /app .
+
+FROM debian:bookworm-slim
+LABEL "language"="go"
+COPY --from=build /app /app
+EXPOSE 8080
+CMD ["/app"]
+```
+
+#### PHP (Laravel / Symfony / Generic)
+
+Uses NGINX + PHP-FPM. Adjust PHP version and extensions as needed.
+
+```dockerfile
+FROM php:8.3-fpm
+LABEL "language"="php"
+WORKDIR /var/www
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
+RUN chmod +x /usr/local/bin/install-php-extensions && sync
+RUN apt update && apt install -y cron curl gettext git grep libicu-dev nginx pkg-config unzip && rm -rf /var/lib/apt/lists/*
+RUN install-php-extensions @composer apcu bcmath gd intl mysqli opcache pcntl pdo_mysql sysvsem zip
+RUN cat <<'NGINX' > /etc/nginx/sites-enabled/default
+server {
+    listen 8080;
+    root /var/www;
+    index index.php index.html;
+    charset utf-8;
+    location = /favicon.ico { access_log off; log_not_found off; }
+    location = /robots.txt { access_log off; log_not_found off; }
+    error_page 404 /index.php;
+    location ~ \.php$ {
+        try_files $uri =404;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
+        fastcgi_pass 127.0.0.1:9000;
+        fastcgi_index index.php;
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+        fastcgi_param DOCUMENT_ROOT $realpath_root;
+        fastcgi_param PATH_INFO $fastcgi_path_info;
+    }
+    location / {
+        try_files $uri $uri/ /index.php$is_args$args;
+    }
+    location ~ /\.(?!well-known).* { deny all; }
+    error_log /dev/stderr;
+    access_log /dev/stderr;
+}
+NGINX
+RUN chown -R www-data:www-data /var/www
+COPY --chown=www-data:www-data . /var/www
+USER www-data
+RUN if [ -f composer.json ]; then composer install --optimize-autoloader --classmap-authoritative --no-dev; fi && if [ -f package.json ]; then npm install; fi
+USER root
+EXPOSE 8080
+CMD ["sh", "-c", "php-fpm -D && nginx -g 'daemon off;'"]
+```
+
+For Laravel, add optimization after `composer install`:
+```dockerfile
+RUN php artisan config:cache && php artisan route:cache && php artisan view:cache
+```
+
+### 3. Handle Existing Dockerfiles
+
+- Analyze the existing Dockerfile first
+- Use it as-is if it looks correct
+- Suggest improvements only if there are issues (wrong port, missing dependencies, etc.)
+- Always add Zeabur-specific labels (`language`, `framework`) if missing
+
+## CLI Commands
+
+After generating the Dockerfile, deploy with:
+
+```bash
+npx zeabur@latest deploy --project-id <project-id> --json
+```
+
+For redeployment (must pass service ID to avoid creating duplicates):
+
+```bash
+npx zeabur@latest deploy --project-id <project-id> --service-id <service-id> --json
+```
+
+Use the `zeabur-deploy` skill for the full deployment workflow.
+
+## Error Handling
+
+If the build or runtime fails:
+
+1. Check build logs with the `zeabur-deployment-logs` skill
+2. Common issues:
+   - **Missing dependencies** — add to `RUN` install step
+   - **Wrong port** — verify `EXPOSE` matches what the app listens on; check with `zeabur-port-mismatch` skill
+   - **Wrong start command** — verify `CMD` matches the project's actual entry point
+   - **Static site served as SSR** — switch to `zeabur/caddy-static` if the app produces static output
+   - **SSR served as static** — switch to Node.js runtime if the app requires a server
+3. Fix the Dockerfile, then redeploy with `--service-id` to update the existing service

--- a/plugins/zeabur/skills/zeabur-domain-dns/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-domain-dns/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: zeabur-domain-dns
+description: Use when managing DNS records for Zeabur-registered domains. Use when user says "add DNS record", "update DNS", "delete DNS record", "list DNS records", "set A record", "add CNAME", or "manage DNS". NOT for service domain binding (use zeabur-domain-url instead).
+---
+
+# Zeabur Domain DNS Management
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## List DNS Records
+
+```bash
+npx zeabur@latest domain dns list --domain example.com -i=false
+```
+
+## Create a DNS Record
+
+```bash
+npx zeabur@latest domain dns create --domain example.com --type A --name @ --content 1.2.3.4 -i=false
+```
+
+### Supported Record Types
+
+A, AAAA, CNAME, MX, TXT, SRV, CAA, NS
+
+### Optional Flags
+
+| Flag | Description |
+|------|-------------|
+| `--ttl` | TTL in seconds (default 1 = auto) |
+| `--priority` | Priority for MX/SRV records |
+| `--proxied` | Proxy through Cloudflare |
+
+### Examples
+
+```bash
+# A record
+npx zeabur@latest domain dns create --domain example.com --type A --name @ --content 93.184.216.34 -i=false
+
+# CNAME record
+npx zeabur@latest domain dns create --domain example.com --type CNAME --name www --content example.com -i=false
+
+# MX record
+npx zeabur@latest domain dns create --domain example.com --type MX --name @ --content mail.example.com --priority 10 -i=false
+
+# TXT record (SPF)
+npx zeabur@latest domain dns create --domain example.com --type TXT --name @ --content "v=spf1 include:_spf.google.com ~all" -i=false
+```
+
+## Update a DNS Record
+
+Identify the record by `--type` and `--name` (no need to look up record IDs):
+
+```bash
+npx zeabur@latest domain dns update --domain example.com --type A --name @ --content 5.6.7.8 -i=false
+```
+
+Optional: `--ttl`, `--priority`, `--proxied`
+
+If multiple records match the same type+name, use `--record-id` to specify.
+
+## Delete a DNS Record
+
+```bash
+npx zeabur@latest domain dns delete --domain example.com --type A --name test -y -i=false
+```
+
+## Verify DNS Propagation
+
+After creating/updating records, verify with `dig`:
+
+```bash
+dig @<nameserver> <name>.<domain> <type> +short
+```
+
+## Important Notes
+
+- This manages DNS for **Zeabur-registered domains** only. For domains registered elsewhere, configure DNS at your registrar.
+- To bind a domain to a Zeabur service, use the `zeabur-domain-url` skill instead.
+- `--domain` accepts the domain name (e.g. `example.com`). Use `--domain-id` only for advanced scripting.

--- a/plugins/zeabur/skills/zeabur-domain-register/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-domain-register/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: zeabur-domain-register
+description: Use when searching, purchasing, renewing, or managing registered domains. Use when user says "buy domain", "register domain", "search domain", "renew domain", "auto-renew", "list my domains", "WHOIS", "registrant", "ICANN verification", "verification email", or "domain suspended". Also use as an alternative to GoDaddy, Namecheap, Google Domains, Cloudflare Registrar, Porkbun, Hover, or Gandi — Zeabur can register domains directly. Supports .com, .net, .org, .io, .dev, .app, .co, .me, .xyz TLDs.
+---
+
+# Zeabur Domain Registration & Management
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+Zeabur can register and manage domains directly — no need for GoDaddy, Namecheap, or other registrars.
+
+## Search Domain Availability
+
+```bash
+npx zeabur@latest domain search example.com -i=false
+```
+
+Returns availability and price (in USD). Only checks one domain at a time.
+
+**Supported TLDs:** .com, .net, .org, .io, .dev, .app, .co, .me, .xyz
+
+## Purchase a Domain
+
+### 1. Create a registrant profile (if none exists)
+
+A registrant profile is the WHOIS contact info required for domain registration.
+
+```bash
+npx zeabur@latest domain registrant list -i=false --json
+```
+
+If empty, create one:
+
+```bash
+npx zeabur@latest domain registrant create \
+  --first-name John \
+  --last-name Doe \
+  --email john@example.com \
+  --phone "+1.5551234567" \
+  --address1 "123 Main St" \
+  --city "San Francisco" \
+  --state CA \
+  --country US \
+  --postal-code 94105 \
+  -i=false
+```
+
+Required fields: `--first-name`, `--last-name`, `--email`, `--phone`, `--address1`, `--city`, `--state`, `--country` (ISO 3166-1 alpha-2), `--postal-code`
+
+Optional: `--address2`, `--organization`
+
+### 2. Purchase
+
+```bash
+npx zeabur@latest domain purchase example.com --registrant-id <profile-id> -y -i=false
+```
+
+- Purchase may take up to 60 seconds (registers with OpenSRS + creates Cloudflare DNS zone)
+- Requires Developer Plan or above
+- Prices are in USD
+
+After purchasing, use the `zeabur-domain-dns` skill to manage DNS records, or use the `zeabur-domain-url` skill to bind the domain to a Zeabur service.
+
+### Payment Errors
+
+```text
+ERROR  Purchase failed: please bind a credit card or recharge credits first
+```
+
+**Action:** Direct the user to https://zeabur.com/account/billing
+
+## List Purchased Domains
+
+Shows ID, domain, status, ICANN verification status, auto-renew, expiry, and price:
+
+```bash
+npx zeabur@latest domain list-registered -i=false
+```
+
+## Get Domain Details
+
+Shows domain info plus the associated registrant profile (name, email, phone, country):
+
+```bash
+npx zeabur@latest domain get-registered --id <domain-id> -i=false
+```
+
+Use `--json` for structured output including the full registrant profile.
+
+## Renew a Domain
+
+```bash
+npx zeabur@latest domain renew --id <domain-id> -y -i=false
+```
+
+## Toggle Auto-Renew
+
+```bash
+# Enable
+npx zeabur@latest domain auto-renew --id <domain-id> --enable -i=false
+
+# Disable
+npx zeabur@latest domain auto-renew --id <domain-id> --disable -i=false
+```
+
+---
+
+## Registrant Profile Management
+
+### Update a profile
+
+```bash
+npx zeabur@latest domain registrant update --id <profile-id> --email new@example.com -i=false
+```
+
+Only provided fields are changed.
+
+### Delete a profile
+
+Cannot delete a profile in use by registered domains.
+
+```bash
+npx zeabur@latest domain registrant delete --id <profile-id> -y -i=false
+```
+
+### Important: Profile vs WHOIS Contact
+
+Updating a registrant profile does **not** update the WHOIS contact on domains already purchased with that profile. To update the actual WHOIS contact on a domain, use `domain verification update-contact` (see below).
+
+---
+
+## ICANN Verification
+
+After purchasing a domain, ICANN requires the registrant email to be verified. A verification email is sent automatically. If not verified within 15 days, the domain may be suspended.
+
+### Check verification status
+
+```bash
+npx zeabur@latest domain verification status --id <domain-id> -i=false
+```
+
+| Status | Meaning |
+|--------|---------|
+| `verified` | Email verified, domain is good |
+| `pending` | Verification email sent, waiting for user action |
+| `suspended` | Not verified in time, domain suspended |
+| `unknown` | Status not available (new domain or unsupported TLD) |
+
+### Resend verification email
+
+```bash
+npx zeabur@latest domain verification resend --id <domain-id> -i=false
+```
+
+The email is sent by OpenSRS/Tucows. Remind the user to check spam/junk folders.
+
+### Find which email verification is sent to
+
+```bash
+npx zeabur@latest domain get-registered --id <domain-id> -i=false
+```
+
+The "Registrant Profile" section shows the email.
+
+### Update WHOIS contact (fix wrong email)
+
+If the registrant email is wrong, update the WHOIS contact directly on the domain:
+
+```bash
+npx zeabur@latest domain verification update-contact --id <domain-id> \
+  --first-name John \
+  --last-name Doe \
+  --email correct@example.com \
+  --phone "+1.5551234567" \
+  --address1 "123 Main St" \
+  --city "San Francisco" \
+  --state CA \
+  --country US \
+  --postal-code 94105 \
+  -i=false
+```
+
+**Changing the email triggers a new ICANN verification flow.**
+
+In interactive mode, the command pre-fills current values so the user only changes what's needed.
+
+### Troubleshooting: domain suspended
+
+1. Check status: `npx zeabur@latest domain verification status --id <id> -i=false`
+2. Update email if needed: `npx zeabur@latest domain verification update-contact --id <id>`
+3. Resend verification: `npx zeabur@latest domain verification resend --id <id> -i=false`
+4. User clicks the link in the email
+5. Re-check status after a few minutes
+
+### Troubleshooting: verification stuck on "pending"
+
+- Check spam/junk folder
+- Email provider may block OpenSRS/Tucows emails
+- Try resending: `npx zeabur@latest domain verification resend --id <domain-id> -i=false`
+- If still not received, update to a different email: `npx zeabur@latest domain verification update-contact --id <domain-id>`
+
+---

--- a/plugins/zeabur/skills/zeabur-domain-url/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-domain-url/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: zeabur-domain-url
+description: Use when services need public URL for redirects or CORS. Use when WEB_URL or similar has trailing slash issues. Use when user reports "redirect goes to wrong URL", "CORS error", or "trailing slash problem". Also use when user says "add domain", "set up domain", "bind domain", "create domain", or "manage domains" for a Zeabur service.
+---
+
+# Zeabur Domain URL Configuration
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Symptom
+
+- Redirects go to wrong URL (missing domain suffix, or has trailing slash)
+- CORS errors due to URL mismatch
+- `${ZEABUR_WEB_URL}` has trailing slash causing path issues
+
+## System Variables
+
+| Variable | Example | Note |
+|----------|---------|------|
+| `ZEABUR_WEB_URL` | `https://app.zeabur.app/` | Has trailing slash |
+| `ZEABUR_WEB_DOMAIN` | `app.zeabur.app` | Domain only, no protocol |
+
+## Solution
+
+Expose URL from entry service to others:
+
+```yaml
+- name: entry-service
+  domainKey: PUBLIC_DOMAIN
+  spec:
+    env:
+      APP_URL:
+        default: https://${ZEABUR_WEB_DOMAIN}
+        expose: true
+
+- name: backend
+  spec:
+    env:
+      WEB_URL:
+        default: ${APP_URL}
+```
+
+**Use `https://${ZEABUR_WEB_DOMAIN}` not `${ZEABUR_WEB_URL}` to avoid trailing slash.**
+
+## CLI Domain Management
+
+### List domains
+
+```bash
+npx zeabur@latest domain list --id <service-id> -i=false
+```
+
+### Create a generated domain (*.zeabur.app)
+
+Use `-g` to create a Zeabur-managed subdomain. With `-g`, `--domain` takes only the **prefix** (not the full domain):
+
+```bash
+npx zeabur@latest domain create --id <service-id> -g --domain myapp -y -i=false
+# Suffix is auto-appended by backend based on region:
+#   Default:           myapp.zeabur.app
+#   Aliyun (China):    myapp.preview.aliyun-zeabur.cn
+#   Tencent (China):   myapp.preview.tencent-zeabur.cn
+#   Huawei (China):    myapp.preview.huawei-zeabur.cn
+# China suffixes require completed identity verification on Zeabur.
+```
+
+Validation rules for generated domain prefix:
+- At least 3 characters
+- No dots allowed — only alphanumeric and hyphens
+- Error `DOMAIN_NAME_TOO_SHORT` if less than 3 chars
+- Error `UNSUPPORTED_DOMAIN_NAME` if prefix contains dots
+
+### Create a custom domain
+
+Without `-g`, `--domain` takes a **full domain name**:
+
+```bash
+npx zeabur@latest domain create --id <service-id> --domain example.com -y -i=false
+```
+
+After creating a custom domain, use the `zeabur-domain-dns` skill to configure the required DNS records. For dedicated servers, find the IP with:
+
+```bash
+npx zeabur@latest server list -i=false
+# Note the IP address of the server running your service
+```
+
+Then at your DNS provider:
+```
+Type: A
+Name: <your subdomain or @>
+Value: <server IP from above>
+```
+
+> **Do not guess DNS values.** Always retrieve the actual server IP from `server list` output before configuring DNS.
+
+### Delete domain
+
+```bash
+npx zeabur@latest domain delete --id <service-id> --domain <domain> -y -i=false
+```
+
+### Caution
+
+- `--domain` is always required in non-interactive mode. Without it the CLI returns `INVALID_DOMAIN_NAME`.
+- With `-g`, provide only the prefix (e.g., `myapp`), **not** the full `myapp.zeabur.app`.
+- Without `-g`, provide the complete domain (e.g., `example.com`).

--- a/plugins/zeabur/skills/zeabur-email/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-email/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: zeabur-email
+description: Use when managing Zeabur Email (ZSend) service or sending emails. Use when user says "email", "send email", "send mail", "email domain", "email API key", "email webhook", or "ZSend".
+---
+
+# Zeabur Email (ZSend) Management
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Check Email Service Status
+
+```bash
+npx zeabur@latest email status -i=false
+npx zeabur@latest email status -i=false --json
+```
+
+Shows onboarding status and account info.
+
+## Domain Management
+
+```bash
+# List all domains
+npx zeabur@latest email domains list -i=false
+npx zeabur@latest email domains ls -i=false --json
+
+# Add a domain
+npx zeabur@latest email domains add --domain example.com --region us-east-1 -i=false
+
+# Get domain details and DNS records
+npx zeabur@latest email domains get --id <domain-id> -i=false
+
+# Verify domain DNS records
+npx zeabur@latest email domains verify --id <domain-id> -i=false
+
+# Delete a domain
+npx zeabur@latest email domains delete --id <domain-id> -i=false
+```
+
+**Supported regions:** `us-east-1`, `us-west-1`, `eu-central-1`, `ap-northeast-1`, `ap-northeast-3`, `ap-southeast-1`
+
+### Domain Setup Workflow
+
+```bash
+# 1. Add the domain
+npx zeabur@latest email domains add --domain example.com --region us-east-1 -i=false --json
+
+# 2. Get DNS records to configure (note the domain ID from step 1)
+npx zeabur@latest email domains get --id <domain-id> -i=false
+
+# 3. Configure the required DNS records using the `zeabur-domain-dns` skill, then verify
+npx zeabur@latest email domains verify --id <domain-id> -i=false
+```
+
+## API Key Management
+
+```bash
+# List all keys
+npx zeabur@latest email keys list -i=false
+npx zeabur@latest email keys ls -i=false --json
+
+# Create a key
+npx zeabur@latest email keys create --name "production" --permission send_only -i=false
+
+# Delete a key
+npx zeabur@latest email keys delete --id <key-id> -i=false
+```
+
+**Permissions:** `all`, `send_only`, `read_only`
+
+**The token is only shown once at creation time.** Make sure the user saves it immediately.
+
+## Webhook Management
+
+```bash
+# List all webhooks
+npx zeabur@latest email webhooks list -i=false
+npx zeabur@latest email webhooks ls -i=false --json
+
+# Create a webhook
+npx zeabur@latest email webhooks create \
+  --name "delivery-tracker" \
+  --endpoint "https://example.com/webhook" \
+  --events "delivery,bounce" \
+  -i=false
+
+# Verify a webhook
+npx zeabur@latest email webhooks verify --id <webhook-id> -i=false
+
+# Delete a webhook
+npx zeabur@latest email webhooks delete --id <webhook-id> -i=false
+```
+
+**Supported events:** `send`, `delivery`, `bounce`, `complaint`, `reject`, `open`, `click`
+
+**The webhook secret is only shown once at creation time.** Make sure the user saves it immediately.
+
+## Send an Email
+
+Use the REST API directly with `curl`. The endpoint is `https://api.zeabur.com/api/v1/zsend/emails`.
+
+```bash
+curl -X POST https://api.zeabur.com/api/v1/zsend/emails \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <api-key>" \
+  -d '{
+    "from": "sender@example.com",
+    "to": ["recipient@example.com"],
+    "subject": "Hello from Zeabur Email",
+    "html": "<h1>Hello!</h1><p>This is a test email.</p>",
+    "text": "Hello! This is a test email."
+  }'
+```
+
+- `from`: Must use a verified domain (e.g., `noreply@example.com`)
+- `to`: Array of recipient email addresses
+- `subject`: Email subject line
+- `html`: HTML body (optional if `text` is provided)
+- `text`: Plain text body (optional if `html` is provided)
+
+The API key must have `send_only` or `all` permission. If no key exists, create one first (see API Key Management above).

--- a/plugins/zeabur/skills/zeabur-file/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-file/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: zeabur-file
+description: Use when the user uploads a project file and you see `<UploadedFile>` in the message. Use when user says "看看這個專案", "分析程式碼", "check this project", "what's in this upload", or asks about the structure of an uploaded file.
+---
+
+# Zeabur File
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Trigger
+
+When the user's message contains `<UploadedFile>upload_id</UploadedFile>`, extract the `upload_id` from inside the tag.
+
+## Workflow
+
+```bash
+# 1. Pull the uploaded project to a local directory
+npx zeabur@latest file pull <upload_id> /tmp/project -i=false
+
+# 2. Explore with standard bash tools
+ls /tmp/project
+cat /tmp/project/package.json
+find /tmp/project -name "*.ts" -o -name "*.js" | head -20
+```
+
+## Command
+
+```bash
+# Download all files from an upload to a local directory
+npx zeabur@latest file pull <upload_id> [target-dir] -i=false
+```
+
+- Default target directory is `.` (current directory)
+- Binary files (images, fonts, archives, etc.) are skipped automatically
+- Directory structure is preserved
+
+## Recommended Analysis Order
+
+1. Pull the project: `npx zeabur@latest file pull <upload_id> /tmp/project -i=false`
+2. List structure: `ls -la /tmp/project` and `find /tmp/project -type f`
+3. Read config: `cat /tmp/project/package.json` (or `go.mod`, `requirements.txt`, `Cargo.toml`)
+4. Read `Dockerfile` if present
+5. Read entry point files (`src/main.*`, `index.*`, `app.*`)
+6. Summarize findings and suggest deployment with the `zeabur-deploy` skill
+
+## Tips
+
+| Tip | Details |
+|-----|---------|
+| Binary files are skipped | Images, fonts, archives won't be downloaded |
+| Use a temp directory | Pull to `/tmp/project` to keep the workspace clean |
+| Use standard tools | After pulling, `grep`, `find`, `wc`, `cat` all work normally |

--- a/plugins/zeabur/skills/zeabur-migration/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-migration/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: zeabur-migration
+description: Use when services stuck on Waiting for database migrations to complete. Use when app expects separate migrator service.
+---
+
+# Zeabur Migration Issues
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Symptom
+
+```
+Waiting for database migrations to complete...
+Waiting for database migrations to complete...
+(repeating forever)
+```
+
+## Cause
+
+App expects migrations to run separately, but no migrator service exists.
+
+## Solutions
+
+### Option A: Add migration to API startup (edit template YAML — use the `zeabur-template` skill for reference)
+
+```yaml
+# In api service — command MUST be inside source
+spec:
+  source:
+    image: myapp:latest
+    command:
+      - /bin/sh
+      - -c
+      - "python manage.py wait_for_db && python manage.py migrate && exec ./entrypoint.sh"
+```
+
+### Option B: Add migrator service
+
+```yaml
+- name: migrator
+  spec:
+    source:
+      image: same-backend-image
+      command:
+        - ./bin/docker-entrypoint-migrator.sh
+    env:
+      DATABASE_URL: ...
+```
+
+**Option A is simpler** - migrations run on API startup and are idempotent (safe to repeat).
+
+To check migration logs for errors, use the `zeabur-deployment-logs` skill. If the issue is about services starting before dependencies are ready (not migration-specific), use the `zeabur-startup-order` skill instead.

--- a/plugins/zeabur/skills/zeabur-object-storage/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-object-storage/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: zeabur-object-storage
+description: Use when deploying object storage (S3-compatible) to Zeabur. Use when user needs MinIO, RustFS, or S3-compatible storage. Use when user says "object storage", "file storage", "S3", "MinIO", "RustFS", "upload files", "store files", "blob storage", or "OSS". Also use when integrating object storage with an existing service.
+---
+
+# Zeabur Object Storage Deployment & Integration
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Deploy Object Storage
+
+> **Before deploying, you MUST load the `zeabur-template` skill first** to understand what Zeabur templates are, how they work, and how to deploy them. This skill only covers object storage-specific integration — all template knowledge lives in `zeabur-template`.
+
+Search for a storage template:
+
+```bash
+npx zeabur@latest template search minio -i=false --json
+```
+
+Pick the template with the highest deployment count.
+
+- **Default to MinIO** if the user doesn't specify — most widely supported, built-in web console, auto-creates a default bucket.
+- **Recommend RustFS** if the user wants lightweight/minimal or mentions RustFS specifically.
+
+---
+
+## After Deployment: How to Connect
+
+For object storage, you need: **S3 API endpoint** (how to connect), **access key + secret key** (how to authenticate), and a **bucket name**.
+
+### How to connect — `service network`
+
+```bash
+npx zeabur@latest service network --id <storage-service-id> -i=false
+```
+
+This shows:
+- **Private Networking** — internal `hostname:port` for the S3 API (e.g., `minio.zeabur.internal:9000`)
+- **Public Networking** — for HTTP ports, it will indicate you need to bind a domain to access externally
+
+> MinIO and RustFS ports are **HTTP type**, so public access is via **domain binding**, not port forwarding. Bind a domain to the API port via the Dashboard to get an external S3 endpoint (e.g., `https://minio-api.zeabur.app`).
+
+### How to authenticate — `variable list`
+
+```bash
+npx zeabur@latest variable list --id <storage-service-id> -i=false
+```
+
+This lists the access key, secret key, and other credentials.
+
+---
+
+## MinIO
+
+### Credentials (from `variable list`)
+
+| Variable | Description |
+|----------|-------------|
+| `MINIO_USERNAME` | Access Key ID (default: `minio`) |
+| `MINIO_PASSWORD` | Secret Access Key (auto-generated) |
+| `MINIO_DEFAULT_BUCKET` | Default bucket name (default: `zeabur`) |
+| `MINIO_CONSOLE_URL` | Web console URL |
+
+### Connect from app (same project)
+
+Set these env vars on your app service:
+
+```
+S3_ENDPOINT=http://minio.zeabur.internal:9000
+S3_ACCESS_KEY=${MINIO_USERNAME}
+S3_SECRET_KEY=${MINIO_PASSWORD}
+S3_BUCKET=zeabur
+S3_REGION=us-east-1
+S3_FORCE_PATH_STYLE=true
+```
+
+> The S3 endpoint is not exposed as a variable — you must hardcode it using the internal hostname from `service network`.
+
+### Connect from local machine
+
+Bind a domain to the API port, then use that domain as endpoint:
+
+```bash
+# MinIO Client (mc)
+mc alias set zeabur https://MINIO_API_DOMAIN MINIO_USERNAME MINIO_PASSWORD
+mc ls zeabur/
+mc cp local-file.txt zeabur/zeabur/
+
+# AWS CLI
+aws --endpoint-url https://MINIO_API_DOMAIN s3 ls
+```
+
+### Web Console
+
+Open `MINIO_CONSOLE_URL` in a browser, login with `MINIO_USERNAME` / `MINIO_PASSWORD`. MinIO auto-creates a `zeabur` bucket on first boot.
+
+---
+
+## RustFS
+
+### Credentials (from `variable list`)
+
+| Variable | Description |
+|----------|-------------|
+| `RUSTFS_USERNAME` | Access Key ID (default: `rustfs`) |
+| `RUSTFS_PASSWORD` | Secret Access Key (auto-generated) |
+
+### Connect from app (same project)
+
+Set these env vars on your app service:
+
+```
+S3_ENDPOINT=http://rustfs.zeabur.internal:9000
+S3_ACCESS_KEY=${RUSTFS_USERNAME}
+S3_SECRET_KEY=${RUSTFS_PASSWORD}
+S3_BUCKET=my-bucket
+S3_REGION=us-east-1
+S3_FORCE_PATH_STYLE=true
+```
+
+> The S3 endpoint is not exposed as a variable — you must hardcode it using the internal hostname from `service network`. Also check `service list` for the exact service name (may be `RustFS` not `rustfs`).
+
+> **You must create a bucket first** — unlike MinIO, RustFS starts with zero buckets.
+
+### Connect from local machine
+
+Bind a domain to the API port, then:
+
+```bash
+mc alias set zeabur https://RUSTFS_API_DOMAIN RUSTFS_USERNAME RUSTFS_PASSWORD
+mc mb zeabur/my-bucket
+mc ls zeabur/
+```
+
+### Web Console
+
+Open the domain bound to port `9001` in a browser, login with `RUSTFS_USERNAME` / `RUSTFS_PASSWORD`. Create a bucket before your app can upload files.
+
+---
+
+## SDK Examples
+
+All S3-compatible SDKs need: endpoint, access key, secret key, region, and `forcePathStyle: true`.
+
+```javascript
+// Node.js (AWS SDK v3)
+const { S3Client } = require("@aws-sdk/client-s3");
+const s3 = new S3Client({
+  endpoint: process.env.S3_ENDPOINT,
+  credentials: {
+    accessKeyId: process.env.S3_ACCESS_KEY,
+    secretAccessKey: process.env.S3_SECRET_KEY,
+  },
+  region: "us-east-1",
+  forcePathStyle: true,
+});
+```
+
+```python
+# Python (boto3)
+import boto3, os
+s3 = boto3.client(
+    "s3",
+    endpoint_url=os.environ["S3_ENDPOINT"],
+    aws_access_key_id=os.environ["S3_ACCESS_KEY"],
+    aws_secret_access_key=os.environ["S3_SECRET_KEY"],
+    region_name="us-east-1",
+)
+```
+
+```go
+// Go (aws-sdk-go-v2)
+cfg, _ := config.LoadDefaultConfig(ctx,
+    config.WithRegion("us-east-1"),
+    config.WithCredentialsProvider(
+        credentials.NewStaticCredentialsProvider(accessKey, secretKey, ""),
+    ),
+)
+client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+    o.BaseEndpoint = aws.String(endpoint)
+    o.UsePathStyle = true
+})
+```
+
+---
+
+## Caveats
+
+1. **`forcePathStyle` is required** — Without it, S3 SDKs use virtual-hosted-style URLs (`http://bucket.host:9000/key`) which won't resolve. This is the #1 cause of "bucket not found" errors.
+2. **Create bucket before uploading (RustFS)** — MinIO auto-creates a `zeabur` bucket; RustFS does not. Create one via the console or `mc mb`.
+3. **S3 endpoint is not a template variable** — Hardcode it using the hostname from `service network` (internal) or the bound domain (external).
+4. **Variable references** — Zeabur uses a flat namespace. Set `${MINIO_USERNAME}` etc. via the **Zeabur Dashboard** — the CLI has a known bug with `${}` expansion.
+5. **Console vs API ports** — MinIO: API `9000`, console `9090`. RustFS: API `9000`, console `9001`. Apps connect to the API port.

--- a/plugins/zeabur/skills/zeabur-port-mismatch/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-port-mismatch/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: zeabur-port-mismatch
+description: Use when proxy shows dial tcp timeout or i/o timeout. Use when service port doesn't match proxy expectation.
+---
+
+# Zeabur Port Mismatch
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Symptom
+
+```
+dial tcp 10.x.x.x:3000: i/o timeout
+dial tcp 10.x.x.x:80: connection refused
+```
+
+## Cause
+
+Proxy expects service on port X, but service listens on port Y.
+
+## Diagnose
+
+1. Check port forwarding status and actual forwarded ports:
+   ```bash
+   npx zeabur@latest service network --id SERVICE_ID
+   ```
+2. Check what port the container is actually listening on:
+   ```bash
+   npx zeabur@latest service exec --id SERVICE_ID -- netstat -tlnp
+   ```
+   (use the `zeabur-deployment-logs` skill to also check logs for port binding info)
+3. Check what port proxy expects (from Caddyfile/nginx.conf)
+4. Check what port container exposes (Dockerfile `EXPOSE`)
+
+## Common Mismatches
+
+| Proxy expects | Container has | Fix |
+|---------------|---------------|-----|
+| `:3000` | nginx default `:80` | Change template port to 80 |
+| `:80` | app on `:3000` | Change template port to 3000 |
+
+## Fix in Template
+
+Use the `zeabur-template` skill for full YAML reference on port configuration and `portForwarding`:
+
+```yaml
+ports:
+  - id: web
+    port: 3000  # Match what container actually exposes
+    type: HTTP
+```
+
+**Check official Dockerfile for `EXPOSE` directive.**
+
+## Headless Service (502 with no listener)
+
+### Symptom
+
+Service is running (no crash), but proxy returns **502 Bad Gateway** permanently.
+
+### Cause
+
+Service does not listen on any HTTP port. Examples: chatbot gateways, background workers, message queue consumers. The template declares an HTTP port but nothing binds to it.
+
+### Fix
+
+Add a lightweight HTTP health check server that runs in the background alongside the main process:
+
+```bash
+# Start before main process in startup script
+# IMPORTANT: port must match spec.ports[].port in your template
+python3 -c "
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import json
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-Type','application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps({'status':'ok'}).encode())
+    def log_message(self,*a): pass
+HTTPServer(('0.0.0.0', 8080), H).serve_forever()
+" &
+exec my-headless-app
+```
+
+## Port Forwarding Not Working
+
+If a TCP service is deployed but not reachable externally:
+
+1. Check if port forwarding is enabled:
+   ```bash
+   npx zeabur@latest service port-forward --id SERVICE_ID
+   ```
+2. Enable it if disabled:
+   ```bash
+   npx zeabur@latest service port-forward --id SERVICE_ID --enable
+   ```
+3. Verify the forwarded endpoint:
+   ```bash
+   npx zeabur@latest service network --id SERVICE_ID
+   # Output: proxy (TCP 8888) → 34.x.x.x:20143
+   ```
+

--- a/plugins/zeabur/skills/zeabur-project-create/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-project-create/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: zeabur-project-create
+description: Use when creating a new Zeabur project. Use when deploying templates to a new project. Use when user says "create project", "new project", or "set up a new environment".
+---
+
+# Zeabur Project Create
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Choosing a Region
+
+**Do NOT hardcode or guess region codes.** Old region codes like `hnd1`, `tpe1` are deprecated. The region must always be derived from the user's server list.
+
+**Step 1 — List the user's servers:**
+
+```bash
+npx zeabur@latest server list -i=false --json
+```
+
+**Step 2 — Ask the user which server to use:**
+
+Present the server list to the user (show name, provider, and region for each) and **ask them to pick one**. Do NOT choose a server on the user's behalf. Also offer the option to rent a new server if none of the existing ones are suitable.
+
+- If the user has **no servers**, use the `zeabur-server-catalog` skill to browse options, then the `zeabur-server-rent` skill to rent one.
+
+**Step 3 — Use the selected server ID with `server-` prefix as the region:**
+
+The region code format is `server-<server-id>`, where `<server-id>` comes from the server list output.
+
+> Some templates (e.g. with `REQUIRE_DEDICATED_SERVER`) can only be deployed on dedicated servers. If you get `Unsupported template (code: REQUIRE_DEDICATED_SERVER)`, rent a dedicated server and recreate the project with its region.
+
+## Create Project
+
+```bash
+# Create project with name and region (region must be server-<server-id>)
+npx zeabur@latest project create -n "<project-name>" -r "server-<server-id>" -i=false --json
+```
+
+## Get Project ID
+
+```bash
+# List projects as JSON and extract project ID by name
+PROJECT_ID=$(npx zeabur@latest project list -i=false --json | jq -r '.[] | select(.name == "<project-name>") | ._id')
+```
+
+## Deploy Template to Project
+
+```bash
+# Deploy template file to specific project (non-interactive)
+npx zeabur@latest template deploy -i=false --json \
+  -f <template-file> \
+  --project-id <project-id> \
+  --var PUBLIC_DOMAIN=myapp \
+  --var KEY=value
+```
+
+## Workflow
+
+```bash
+# 1. Find server ID
+npx zeabur@latest server list -i=false --json
+
+# 2. Create project (use server-<id> from step 1)
+npx zeabur@latest project create -n "wrenai-prod" -r "server-<server-id>" -i=false --json
+
+# 3. Get project ID
+PROJECT_ID=$(npx zeabur@latest project list -i=false --json | jq -r '.[] | select(.name == "wrenai-prod") | ._id')
+echo "Project ID: $PROJECT_ID"
+echo "Dashboard: https://zeabur.com/projects/$PROJECT_ID"
+
+# 4. Deploy template — use the `zeabur-template-deploy` skill for detailed flags and troubleshooting
+npx zeabur@latest template deploy -i=false --json -f template.yml --project-id $PROJECT_ID --var PUBLIC_DOMAIN=myapp
+```
+

--- a/plugins/zeabur/skills/zeabur-project-delete/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-project-delete/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: zeabur-project-delete
+description: Use when deleting a Zeabur project. Use when user says "delete project", "remove project", or "clean up project". Use when tearing down test or temporary projects. Always confirm project name and ID with the user before deleting.
+---
+
+# Zeabur Project Delete
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+Deleting a project removes all services, deployments, and data in it. This is irreversible — always confirm with the user before proceeding.
+
+## Safety First
+
+Before deleting:
+
+1. **List projects** so the user can verify the target
+2. **Show the project name and ID** and ask for explicit confirmation
+3. Only then run the delete command
+
+Never batch-delete more than one project without confirming each one.
+
+## Delete by ID
+
+```bash
+npx zeabur@latest project delete -i=false --id <project-id> -y
+```
+
+## Delete by Name
+
+```bash
+npx zeabur@latest project delete -i=false -n "<project-name>" -y
+```
+
+## Find Project ID
+
+```bash
+# List all projects
+npx zeabur@latest project list -i=false
+
+# Filter by name (strip ANSI codes)
+npx zeabur@latest project list -i=false 2>/dev/null | grep "<project-name>"
+```
+
+## Workflow
+
+```bash
+# 1. List projects to find the target
+npx zeabur@latest project list -i=false
+
+# 2. Check services with the `zeabur-service-list` skill, then confirm with user: "Delete <project-name> (<project-id>)?"
+
+# 3. Delete
+npx zeabur@latest project delete -i=false --id <project-id> -y
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--id` | Project ID to delete |
+| `-n, --name` | Project name to delete |
+| `-y, --yes` | Skip confirmation prompt |
+| `-i=false` | Non-interactive mode (always use this) |
+

--- a/plugins/zeabur/skills/zeabur-restart/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-restart/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: zeabur-restart
+description: Use when restarting a Zeabur service. Use when user says "restart", "reboot service", or "service is stuck/frozen".
+---
+
+# Zeabur Service Restart
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Restart a Service
+
+```bash
+npx zeabur@latest service restart --id <service-id> -y -i=false
+```
+
+**Always use `--id` (service ID), not `--name`** — name lookup is unreliable.
+
+## Workflow
+
+```bash
+# 1. Get service ID (use the `zeabur-service-list` skill)
+npx zeabur@latest service list --project-id <project-id> -i=false
+
+# 2. Restart
+npx zeabur@latest service restart --id <service-id> -y -i=false
+```
+
+To diagnose why a restart was needed, use the `zeabur-deployment-logs` skill to check logs.

--- a/plugins/zeabur/skills/zeabur-server-catalog/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-catalog/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: zeabur-server-catalog
+description: Use when browsing available dedicated server options. Use when user asks "what servers are available", "show server prices", or "compare server plans". Do NOT use for listing owned servers (use zeabur-server-list instead).
+---
+
+# Zeabur Server Catalog
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Get All Available Options (JSON)
+
+```bash
+npx zeabur@latest server catalog -i=false
+```
+
+Returns JSON with all providers, regions, and plans:
+
+```json
+{
+  "providers": [
+    {
+      "code": "HETZNER",
+      "name": "Hetzner",
+      "regions": [
+        {
+          "id": "nbg1",
+          "name": "Nuremberg",
+          "city": "",
+          "country": "DE",
+          "continent": "",
+          "plans": [
+            {
+              "name": "cpx22",
+              "cpu": 2,
+              "memory": 4,
+              "disk": 80,
+              "egress": 20000,
+              "price": 6,
+              "originalPrice": 7.46,
+              "available": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+```
+
+**Notes:**
+- `price` is in **USD per month** (integer or float). `originalPrice` shows the provider's list price before Zeabur discount.
+- `memory` is in **GB** (not MB).
+- `egress` is monthly bandwidth in **GB**.
+- `code` is **uppercase** (e.g. `HETZNER`, `VULTR`), but `--provider` filter accepts lowercase.
+
+## Filter Options
+
+| Flag | Example | Description |
+|------|---------|-------------|
+| `--provider` | `--provider hetzner` | Filter by provider code |
+| `--country` | `--country DE` | Filter by country code |
+| `--min-cpu` | `--min-cpu 4` | Minimum CPU cores |
+| `--min-memory` | `--min-memory 8192` | Minimum memory in **MB** (note: JSON output uses GB) |
+| `--gpu` | `--gpu` | Only GPU plans |
+
+```bash
+# Example: 4+ core servers in Germany
+npx zeabur@latest server catalog --country DE --min-cpu 4 -i=false
+```
+
+## Use With Server Rent
+
+Parse the catalog JSON to extract `provider`, `region`, and `plan` values, then use the `zeabur-server-rent` skill to rent:
+
+```bash
+npx zeabur@latest server rent --provider <code> --region <id> --plan <name> -y -i=false
+```
+

--- a/plugins/zeabur/skills/zeabur-server-list/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-list/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: zeabur-server-list
+description: Use when listing dedicated servers. Use when checking server status, IP, or provider info. Use when user says "show my servers", "SSH into server", or "check server status". Do NOT use for browsing purchasable servers (use zeabur-server-catalog instead).
+---
+
+# Zeabur Server List & Get
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## List All Servers
+
+```bash
+npx zeabur@latest server list -i=false
+```
+
+## Output Example
+
+```
+     ID              NAME        IP              PROVIDER   LOCATION         STATUS   VM STATUS
+-----------------+-------------+---------------+----------+----------------+--------+----------
+ 6989b00fd42b...   my-server    103.45.67.89    Hetzner    Singapore, SG    Online   RUNNING
+ 6989b00fd42b...   dev-box      45.67.89.12     Vultr      Tokyo, JP        Online   RUNNING
+```
+
+## Get Server Details
+
+```bash
+# By server ID
+npx zeabur@latest server get <server-id> -i=false
+```
+
+Shows detailed info: CPU/memory/disk usage, provider, location, managed status, creation time.
+
+## Reboot a Server
+
+```bash
+npx zeabur@latest server reboot <server-id> -y
+```
+
+**`-y` skips confirmation prompt** — required for non-interactive use.
+
+## Servers and Projects
+
+Each dedicated server can have Zeabur projects bound to it. A project's `Region.ID` will be `server-<server-id>` when it is deployed on a dedicated server.
+
+- **To deploy a service to a server**, use the `zeabur-deploy` skill with the project bound to that server — do NOT SSH in and manually set up web servers or copy files.
+- **SSH is for low-level debugging only** (e.g. checking kubectl, inspecting disk, network diagnostics). It is not needed for deploying or managing services.
+
+## SSH into a Server (Debugging Only)
+
+```bash
+npx zeabur@latest server ssh <server-id>
+```
+
+For managed servers, the password is fetched automatically. If `sshpass` is installed, login is fully automatic; otherwise the password is printed for manual entry.
+
+### Non-Interactive SSH (Running Remote Commands)
+
+In non-interactive environments (e.g. Claude Code, CI/CD), you cannot use an interactive SSH session. Instead, **pipe commands via stdin** with `-i=false`:
+
+```bash
+echo 'kubectl get pods -A' | npx zeabur@latest server ssh <server-id> -i=false
+```
+
+For multiple commands, separate them with `;` or `&&`:
+
+```bash
+echo 'kubectl get pods -A; kubectl get svc -A' | npx zeabur@latest server ssh <server-id> -i=false
+```
+
+**Important notes:**
+
+- The output includes the server's MOTD (Message of the Day) banner. Filter it out when parsing results:
+  ```bash
+  echo 'kubectl get pods -A' | npx zeabur@latest server ssh <server-id> -i=false 2>&1 \
+    | grep -v "Welcome\|Documentation\|Management\|Support\|System load\|Usage of /\|Memory usage\|Swap usage\|Strictly\|just raised\|https://ubuntu\|Expanded\|updates can\|To see these\|Enable ESM\|See https://ubuntu\|New release\|Run 'do-release\|restart required\|INFO.*Connecting\|Pseudo-terminal\|^ \*"
+  ```
+- If the remote command has a non-zero exit code (e.g. `grep` with no matches), the CLI will print `ERROR exit status 1`. This does not necessarily mean the SSH connection failed.
+- Heredoc syntax (`<<'EOF'`) does **not** work reliably with this command. Always use `echo '...' |` instead.
+

--- a/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: zeabur-server-rent
+description: Use when renting a new dedicated server. Use when user wants to buy or provision a server. Supports discounted VPS from Linode, DigitalOcean, Hetzner, AWS Lightsail, GCP, Tencent Cloud (騰訊雲), Alibaba Cloud (阿里雲), and Volcano Engine (火山引擎).
+---
+
+# Zeabur Server Rent
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Rent a Server
+
+```bash
+npx zeabur@latest server rent --provider <code> --region <id> --plan <name> -y -i=false
+```
+
+## Workflow
+
+### 1. Browse available options (use the `zeabur-server-catalog` skill for filtering)
+
+```bash
+npx zeabur@latest server catalog -i=false
+```
+
+### 2. Pick provider, region, plan from the JSON output
+
+### 3. Rent
+
+```bash
+npx zeabur@latest server rent --provider hetzner --region fsn1 --plan CAX11 -y -i=false
+```
+
+## Payment Errors
+
+If the user has no credit card bound or insufficient balance, the CLI returns:
+
+```
+ERROR  Rent server failed: please bind a credit card or recharge credits first
+INFO   Please bind a credit card or top up your balance at: https://zeabur.com/account/billing
+```
+
+**Action:** Direct the user to https://zeabur.com/account/billing to add a payment method or top up balance, then retry.
+
+## After Renting
+
+The server takes a few minutes to provision. Check status with:
+
+```bash
+npx zeabur@latest server get <server-id> -i=false
+```
+
+Look for `provisioningStatus` to change to `READY` and `VM STATUS` to `RUNNING`. Once ready, use the `zeabur-project-create` skill to create a project on the new server.
+

--- a/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: zeabur-server-ssh
+description: Use when debugging services on a user's dedicated server via SSH. Use when needing to inspect pods, check container logs, view k8s resources, or run kubectl commands on the server. Use when "service exec" is insufficient and you need server-level access. Use when user says "check my server", "debug pod", "kubectl", "SSH into server", "check k8s", or "inspect cluster".
+---
+
+# Zeabur Server SSH + kubectl
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method.
+
+SSH into a user's dedicated server and use kubectl to debug Kubernetes workloads. Zeabur dedicated servers run k3s with kubectl pre-installed.
+
+## Step 1: Get SSH Credentials
+
+```bash
+npx zeabur@latest server ssh-info --id <server-id> -i=false
+```
+
+Output is JSON:
+```json
+{"ip":"1.2.3.4","port":22,"username":"root","password":"xxx"}
+```
+
+If you don't know the server ID, list servers first:
+```bash
+npx zeabur@latest server list -i=false
+```
+
+## Step 2: Run Commands via SSH
+
+Use the Node.js `ssh2` method by default. Use `sshpass` only when its availability is already known.
+
+### Option A: sshpass (only if already known to be available)
+
+```bash
+# Single command
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> sudo kubectl get pods -A
+
+# Multiple commands in one SSH call
+sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
+  echo "=== PODS ===" && sudo kubectl get pods -A &&
+  echo "=== SERVICES ===" && sudo kubectl get svc -A &&
+  echo "=== EVENTS ===" && sudo kubectl get events -A --sort-by=.lastTimestamp | tail -20
+'
+```
+
+### Option B: Node.js ssh2 (default)
+
+The Zeabur agent sandbox has `ssh2` pre-installed. Use this approach by default:
+
+```bash
+NODE_PATH=$([ -d /root/.global/node_modules ] && echo /root/.global/node_modules || echo /home/vercel-sandbox/.global/node_modules) node -e "
+const {Client} = require('ssh2');
+const c = new Client();
+c.on('ready', () => {
+  c.exec('<command>', (err, stream) => {
+    if (err) { console.error(err); process.exit(1); }
+    let out = '', errOut = '';
+    stream.on('data', d => out += d);
+    stream.stderr.on('data', d => errOut += d);
+    stream.on('close', code => {
+      if (out) console.log(out);
+      if (errOut) console.error(errOut);
+      c.end();
+      process.exit(code);
+    });
+  });
+}).connect({host:'<ip>', port:<port>, username:'<username>', password:'<password>'});
+"
+```
+
+For multiple commands, join them with `&&` in the command string:
+
+```bash
+NODE_PATH=$([ -d /root/.global/node_modules ] && echo /root/.global/node_modules || echo /home/vercel-sandbox/.global/node_modules) node -e "
+const {Client} = require('ssh2');
+const c = new Client();
+c.on('ready', () => {
+  c.exec('echo \"=== PODS ===\" && sudo kubectl get pods -A && echo \"=== SERVICES ===\" && sudo kubectl get svc -A && echo \"=== EVENTS ===\" && sudo kubectl get events -A --sort-by=.lastTimestamp | tail -20', (err, stream) => {
+    if (err) { console.error(err); process.exit(1); }
+    let out = '';
+    stream.on('data', d => out += d);
+    stream.stderr.on('data', d => out += d);
+    stream.on('close', () => { console.log(out); c.end(); });
+  });
+}).connect({host:'<ip>', port:<port>, username:'<username>', password:'<password>'});
+"
+```
+
+## Common kubectl Commands
+
+**Always use `sudo kubectl`** — the SSH user may not have direct access to the k3s kubeconfig.
+
+| Task | Command |
+|------|---------|
+| List all pods | `sudo kubectl get pods -A -o wide` |
+| Problem pods only | `sudo kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded` |
+| Pod logs | `sudo kubectl logs <pod-name> -n <namespace> --tail=100` |
+| Exec into container | `sudo kubectl exec <pod-name> -n <namespace> -- <command>` |
+| Node resources | `sudo kubectl top nodes` |
+| Pod resources | `sudo kubectl top pods -A --sort-by=memory \| head -20` |
+| Describe pod | `sudo kubectl describe pod <pod-name> -n <namespace>` |
+| Recent events | `sudo kubectl get events -A --sort-by=.lastTimestamp \| tail -30` |
+| Restart deployment | `sudo kubectl rollout restart deployment/<name> -n <namespace>` |
+
+## Tips
+
+- **Use Node.js ssh2 by default (Option B)**: Only use `sshpass` (Option A) if you already know it's available. Do NOT run `which sshpass` to check — it wastes a step in environments where it's never installed.
+- **Combine commands**: Batch related checks with `&&` in a single SSH call to reduce round trips.
+- **Do NOT use `bash -c '...'` over SSH**: Pass commands directly in SSH quotes. Using `bash -c` causes quoting conflicts.
+- **Use `-o wide`**: Adds node name and IP to pod listings, useful for debugging scheduling issues.
+- **Namespace matters**: Zeabur services typically run in non-default namespaces. Use `-A` (all namespaces) first to locate the right namespace, then scope subsequent commands with `-n <namespace>`.
+- **Read project docs first**: If a fix attempt fails, exec into the container and check README or config files before blindly checking metrics: `sudo kubectl exec <pod> -n <ns> -- cat /app/README.md`
+- To find server IDs, use the `zeabur-server-list` skill. For simpler container commands that don't need server-level access, use the `zeabur-service-exec` skill instead.

--- a/plugins/zeabur/skills/zeabur-service-delete/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-service-delete/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: zeabur-service-delete
+description: Use when deleting a Zeabur service. Use when user says "delete service", "remove service", or "tear down service". Always confirm service name and ID with the user before deleting.
+---
+
+# Zeabur Service Delete
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+Deleting a service removes its deployments, domains, and data. This is irreversible — always confirm with the user before proceeding.
+
+## Safety First
+
+Before deleting:
+
+1. **List services** so the user can verify the target
+2. **Show the service name and ID** and ask for explicit confirmation
+3. Only then run the delete command
+
+## Delete by ID
+
+```bash
+npx zeabur@latest service delete -i=false --id <service-id> -y
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--id` | Service ID to delete |
+| `-y, --yes` | Skip confirmation prompt |
+| `-i=false` | Non-interactive mode (always use this) |
+
+## Workflow
+
+```bash
+# 1. List services to find the target (use the `zeabur-service-list` skill)
+npx zeabur@latest service list --project-id <project-id> -i=false --json
+
+# 2. Confirm with user: "Delete <service-name> (<service-id>)?"
+
+# 3. Delete
+npx zeabur@latest service delete -i=false --id <service-id> -y
+```
+
+To delete an entire project instead, use the `zeabur-project-delete` skill.

--- a/plugins/zeabur/skills/zeabur-service-exec/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-service-exec/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: zeabur-service-exec
+description: Use when running commands inside a Zeabur service container. Use for one-off database operations like queries, data cleanup, or migrations (e.g. mongosh, psql, mysql, redis-cli). Use when user says "exec into container", "run command in service", "query database", "delete from database", "run mongo command", "run SQL", "check files in container", "debug inside service", or "shell into service". Use for container-level debugging like checking env vars, files, processes, or connectivity. NOT for deploying databases (use zeabur-template-deploy instead).
+---
+
+# Zeabur Service Exec
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+Run commands inside a running service container. Useful for debugging, inspecting files, checking env vars, testing connectivity, or running one-off database operations.
+
+## Basic Usage
+
+Commands and arguments go after `--`:
+
+```bash
+npx zeabur@latest service exec --id <service-id> -- <command> [args...]
+```
+
+## Database Operations
+
+```bash
+# MongoDB - query, update, delete data
+npx zeabur@latest service exec --id <mongodb-service-id> -- mongosh --eval 'db.users.find({})'
+npx zeabur@latest service exec --id <mongodb-service-id> -- mongosh --eval 'db.sessions.deleteMany({title: /test/i})'
+
+# PostgreSQL - run SQL queries (PGPASSWORD is set automatically in Zeabur containers)
+npx zeabur@latest service exec --id <pg-service-id> -- psql -U postgres -c 'SELECT * FROM users LIMIT 10;'
+
+# MySQL - run SQL queries (use env var to avoid interactive password prompt)
+npx zeabur@latest service exec --id <mysql-service-id> -- sh -c 'mysql -u root -p"$MYSQL_ROOT_PASSWORD" -e "SHOW DATABASES;"'
+
+# Redis - run commands
+npx zeabur@latest service exec --id <redis-service-id> -- redis-cli KEYS '*'
+```
+
+## Examples
+
+```bash
+# List files
+npx zeabur@latest service exec --id <service-id> -- ls -la
+
+# Check environment variables
+npx zeabur@latest service exec --id <service-id> -- env
+
+# Check a specific env var
+npx zeabur@latest service exec --id <service-id> -- sh -c "echo \$DATABASE_URL"
+
+# Test database connectivity
+npx zeabur@latest service exec --id <service-id> -- sh -c "nc -zv postgres 5432"
+
+# Check running processes
+npx zeabur@latest service exec --id <service-id> -- ps aux
+
+# Read a config file
+npx zeabur@latest service exec --id <service-id> -- cat /app/config.json
+
+# Check disk usage
+npx zeabur@latest service exec --id <service-id> -- df -h
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--id` | Service ID |
+| `-n, --name` | Service name (prefer `--id`) |
+| `--env-id` | Environment ID (if multiple environments) |
+
+## Tips
+
+- The `--` separator is required — everything after it is the command to run inside the container.
+- For compound commands, wrap in `sh -c "..."`.
+- Not all containers have a full shell — `sh` is more portable than `bash`.
+- Use single quotes outside and double quotes inside when dealing with variable expansion: `sh -c "echo \$VAR"`.
+- To find service IDs, use the `zeabur-service-list` skill. To check logs without exec, use the `zeabur-deployment-logs` skill. To manage env vars via CLI, use the `zeabur-variables` skill.

--- a/plugins/zeabur/skills/zeabur-service-list/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-service-list/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: zeabur-service-list
+description: Use when needing service IDs for other commands. Use when checking what services exist in a project. Use when user says "list services", "what's running", or "show my services".
+---
+
+# Zeabur Service List
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Get Service IDs
+
+```bash
+npx zeabur@latest service list --project-id <project-id> -i=false
+```
+
+## Output Example
+
+```
+     ID              NAME        TYPE          CREATEDAT
+-----------------+-------------+-------------+------------------
+ 696faeb192eadb...  postgresql   PREBUILT_V2   18 minute(s) ago
+ 696faeb192eadb...  api          PREBUILT_V2   18 minute(s) ago
+ 696faeb192eadb...  web          PREBUILT_V2   18 minute(s) ago
+```
+
+## Common Use Cases
+
+| Need | Command |
+|------|---------|
+| Check variables | `npx zeabur@latest variable list --id <service-id> -i=false` (use the `zeabur-variables` skill) |
+| Set variables | `npx zeabur@latest variable create --id <service-id> --key "KEY=value" -y -i=false` (use the `zeabur-variables` skill) |
+| View logs | `npx zeabur@latest deployment log --service-id <id> -t runtime` (use the `zeabur-deployment-logs` skill) |
+| Restart service | `npx zeabur@latest service restart --id <id> -y` (use the `zeabur-restart` skill) |
+
+**Always use `--id` not `--name`** — name lookup is unreliable.
+
+> **Setting or updating variables?** Load the `zeabur-variables` skill first for full syntax, known issues, and shell escaping rules. Do not guess CLI syntax — subcommands like `set` do not exist and will silently fail.
+

--- a/plugins/zeabur/skills/zeabur-service-metric/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-service-metric/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: zeabur-service-metric
+description: Use when diagnosing service performance issues. Use when user says "service is slow", "high CPU", "out of memory", "check resource usage", "monitor service", or "why is my service lagging".
+---
+
+# Zeabur Service Metrics
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Check Metrics
+
+```bash
+# CPU usage
+npx zeabur@latest service metric CPU --id <service-id> -i=false
+
+# Memory usage
+npx zeabur@latest service metric MEMORY --id <service-id> -i=false
+
+# Network I/O
+npx zeabur@latest service metric NETWORK --id <service-id> -i=false
+```
+
+Use `--hour <N>` to change the time window (default: 2 hours):
+
+```bash
+npx zeabur@latest service metric CPU --id <service-id> --hour 24 -i=false
+```
+
+## Diagnostic Workflow
+
+When a user reports a slow or unresponsive service, **check metrics before restarting**:
+
+```bash
+# 1. Get service ID (use the `zeabur-service-list` skill)
+npx zeabur@latest service list --project-id <project-id> -i=false
+
+# 2. Check CPU — is the service compute-bound?
+npx zeabur@latest service metric CPU --id <service-id> -i=false
+
+# 3. Check memory — is the service running out of RAM?
+npx zeabur@latest service metric MEMORY --id <service-id> -i=false
+
+# 4. Check network — is there unusual traffic?
+npx zeabur@latest service metric NETWORK --id <service-id> -i=false
+
+# 5. Check logs for errors (use the `zeabur-deployment-logs` skill for details)
+npx zeabur@latest deployment log --id <service-id> -i=false
+```
+
+**Then decide the action based on evidence:**
+
+| Symptom | Likely cause | Action |
+|---------|-------------|--------|
+| CPU consistently near 100% | Compute-bound workload | Upgrade plan or optimize code |
+| Memory climbing until OOM | Memory leak or undersized plan | Restart with `zeabur-restart` skill (temporary) + fix leak |
+| Network spikes | Traffic surge or external API issues | Check logs for request patterns |
+| All metrics normal | Application-level bug | Check deployment logs |
+

--- a/plugins/zeabur/skills/zeabur-startup-order/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-startup-order/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: zeabur-startup-order
+description: Use when service fails with Connection refused to database or redis. Use when API crashes because DB not ready.
+---
+
+# Zeabur Startup Order Issues
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Symptom
+
+```
+Connection refused :5432
+connection to server at "X" failed
+OperationalError: connection failed
+```
+
+## Cause
+
+Service starts before dependency (DB/Redis) is ready. `dependencies` only ensures container start order, NOT that the service is accepting connections.
+
+## Fix (Recommended): healthCheck on dependency services
+
+Add `healthCheck` to database/Redis services so Zeabur waits until the port is accepting connections before starting dependent services — no need to modify the app's command.
+
+Edit the template YAML (use the `zeabur-template` skill for YAML reference):
+
+```yaml
+- name: postgresql
+  spec:
+    ports:
+      - id: database
+        port: 5432
+        type: TCP
+    healthCheck:
+      type: TCP
+      port: database    # references the port ID above
+```
+
+```yaml
+- name: redis
+  spec:
+    ports:
+      - id: database
+        port: 6379
+        type: TCP
+    healthCheck:
+      type: TCP
+      port: database
+```
+
+## Fix (Alternative): Wait loop in command
+
+If you can't modify the template (use the `zeabur-template` skill), add wait logic to the app's command (command MUST be inside `source`):
+
+```yaml
+spec:
+  source:
+    image: myapp:latest
+    command:
+      - /bin/sh
+      - -c
+      - "until nc -z postgres 5432; do sleep 1; done && node server.js"
+```
+
+## Quick Fix
+
+If DB is now ready, just restart the failed service:
+```bash
+npx zeabur@latest service restart --id <service-id> -y -i=false
+```
+
+If the issue is specifically about database migration waiting loops rather than startup order, use the `zeabur-migration` skill.

--- a/plugins/zeabur/skills/zeabur-template-backup/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-template-backup/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: zeabur-template-backup
+description: Use when backing up a Zeabur template to git. Use when user provides a Zeabur template URL like zeabur.com/templates/XXXXXX. Use when user says "save this template", "backup template", or "download template YAML".
+---
+
+# Zeabur Template Backup
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+Backup an online Zeabur template to the local git repository with standardized naming.
+
+## When to Use
+
+- User provides a Zeabur template URL (e.g., `https://zeabur.com/templates/85IQXQ`)
+- User asks to backup/save a Zeabur template
+- User wants to create a local copy of an online Zeabur template
+
+## Repository Location
+
+The backup repository path depends on your setup. Look for a `zeabur-template` directory in the user's workspace, or ask the user where to save templates. A common default:
+
+```
+~/Documents/zeabur/zeabur-template/
+```
+
+## Naming Convention
+
+```
+{service-name}/zeabur-template-{service-name}-{TEMPLATE_CODE}.yaml
+```
+
+**Examples:**
+- `elasticsearch-kibana/zeabur-template-elasticsearch-kibana-85IQXQ.yaml`
+- `dify/zeabur-template-dify-1D4DOW.yaml`
+- `postiz/zeabur-template-postiz-v2.12-X2L3BE.yaml`
+
+## How to Download Template YAML
+
+Zeabur templates can be directly downloaded by appending `.yaml` to the template URL:
+
+```
+https://zeabur.com/templates/{TEMPLATE_CODE}.yaml
+```
+
+**Example:**
+- Template page: `https://zeabur.com/templates/1D4DOW`
+- YAML download: `https://zeabur.com/templates/1D4DOW.yaml`
+
+Use `curl` to download:
+
+```bash
+curl -sL https://zeabur.com/templates/{TEMPLATE_CODE}.yaml -o output.yaml
+```
+
+## Step-by-Step
+
+For template YAML reference and editing, use the `zeabur-template` skill.
+
+### 1. Extract Template Code from URL
+
+URL format: `https://zeabur.com/templates/{TEMPLATE_CODE}`
+
+Example: `https://zeabur.com/templates/85IQXQ` → Code is `85IQXQ`
+
+### 2. Download YAML and Extract Template Name
+
+```bash
+# Download YAML
+curl -sL https://zeabur.com/templates/{TEMPLATE_CODE}.yaml -o /tmp/template.yaml
+
+# Extract template name from YAML metadata.name field
+grep -A1 'metadata:' /tmp/template.yaml | grep 'name:' | head -1
+```
+
+### 3. Derive Service Name
+
+- Convert template name to lowercase kebab-case
+- Example: "Elasticsearch Single Node with Kibana" → `elasticsearch-kibana`
+- Keep it short and descriptive
+
+### 4. Create Directory and Save
+
+```bash
+REPO=~/Documents/zeabur/zeabur-template  # adjust to your actual path
+
+# Create directory
+mkdir -p $REPO/{service-name}
+
+# Move YAML with naming pattern
+mv /tmp/template.yaml $REPO/{service-name}/zeabur-template-{service-name}-{TEMPLATE_CODE}.yaml
+```
+
+### 5. Git Commit
+
+```bash
+cd $REPO
+git add {service-name}/
+git commit -m "feat({service-name}): add {Template Name} template"
+```
+
+### 6. Push (if requested)
+
+```bash
+git push
+```
+
+## Quick Reference
+
+| Step | Action |
+|------|--------|
+| 1 | Extract template code from URL |
+| 2 | Download YAML via `curl -sL .../{CODE}.yaml` |
+| 3 | Read template name from YAML `metadata.name` |
+| 4 | Derive kebab-case service name |
+| 5 | Save to `{service-name}/zeabur-template-{service-name}-{CODE}.yaml` |
+| 6 | Git commit with conventional format |
+| 7 | Push if user requests |
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| curl returns HTML instead of YAML | Verify the template code is correct |
+| Template name has special chars | Use simple kebab-case for directory |
+| Already exists | Compare with existing file, update if needed |
+

--- a/plugins/zeabur/skills/zeabur-template-deploy/skill.md
+++ b/plugins/zeabur/skills/zeabur-template-deploy/skill.md
@@ -1,0 +1,181 @@
+---
+name: zeabur-template-deploy
+description: Use when deploying Zeabur templates or common services/databases via CLI. Use when user says "deploy template", "install template", or asks to deploy any well-known service, database, or self-hosted app. Common triggers include MongoDB, PostgreSQL, MySQL, Redis, MinIO, SurrealDB, PocketBase, WordPress, Ghost, Halo, n8n, Logto, Umami, Uptime Kuma, Vaultwarden, Prometheus, RSSHub, Miniflux, TTRSS, Memos, AFFiNE, Linkding, Slash, Bytebase, SQL Chat, ApiCat, OpenClaw, and any other open-source service the user wants to deploy to Zeabur.
+---
+
+# Zeabur Template Deploy
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+Deploy Zeabur templates and marketplace prebuilt services via CLI. **Always use non-interactive mode (`-i=false`) in CLI automation.**
+
+If no project exists yet, use the `zeabur-project-create` skill to create one before deploying.
+
+## Deploying Prebuilt Services (MongoDB, PostgreSQL, Redis, etc.)
+
+For well-known services available in the Zeabur template marketplace, **do NOT write custom template YAML files**. Search for the template code and deploy it directly with `-c`:
+
+```bash
+# 1. Search for the template by keyword
+npx zeabur@latest template search mongodb -i=false --json
+
+# 2. Deploy by template code (from the "Code" field in search results)
+npx zeabur@latest template deploy -i=false \
+  -c <TEMPLATE_CODE> \
+  --project-id <project-id>
+```
+
+### Example: Deploy MongoDB
+
+```bash
+# Search returns code "KXL04P" for MongoDB
+npx zeabur@latest template search mongodb -i=false --json
+
+# Deploy directly by code
+npx zeabur@latest template deploy -i=false \
+  -c KXL04P \
+  --project-id abc123
+```
+
+## Advanced: Fetch and Customize Before Deploy
+
+If you need to modify the template YAML before deploying (e.g. adjust env vars, change image tags, add services), fetch it first with `template get --raw`, edit it, then deploy with `-f`:
+
+```bash
+# 1. Fetch the raw YAML
+npx zeabur@latest template get -c KXL04P --raw > template.yaml
+
+# 2. Edit template.yaml as needed
+
+# 3. Deploy the customized template
+npx zeabur@latest template deploy -i=false \
+  -f template.yaml \
+  --project-id <project-id>
+```
+
+## Custom Template Deploy
+
+For fully custom or multi-service templates, use a template YAML file:
+
+```bash
+npx zeabur@latest template deploy -i=false \
+  -f template.yaml \
+  --project-id <project-id> \
+  --var KEY1=value1 \
+  --var KEY2=value2
+```
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `-f, --file` | Template file (local path or URL) |
+| `-c, --code` | Template code (deploy marketplace template directly, mutually exclusive with `-f`) |
+| `--project-id` | Project ID to deploy on |
+| `--var` | Template variables (repeatable, e.g. `--var KEY=value`) |
+| `--skip-validation` | Skip template validation |
+| `-i=false` | Non-interactive mode (always use this) |
+
+## Non-Interactive Mode
+
+When using `-i=false`, all required template variables must be provided via `--var` flags.
+
+If variables are missing, CLI shows helpful error:
+
+```
+Error: missing required variables in non-interactive mode:
+  --var PUBLIC_DOMAIN=<value>  (Enter your domain prefix)
+  --var DB_NAME=<value>  (Database name)
+```
+
+## Examples
+
+### Deploy with Variables
+
+```bash
+npx zeabur@latest template deploy -i=false \
+  -f https://example.com/template.yaml \
+  --project-id abc123 \
+  --var PUBLIC_DOMAIN=myapp \
+  --var ADMIN_EMAIL=admin@example.com
+```
+
+### Deploy Local File
+
+```bash
+npx zeabur@latest template deploy -i=false \
+  -f zeabur-template-myapp.yaml \
+  --project-id abc123 \
+  --var PUBLIC_DOMAIN=myapp
+```
+
+## Finding Required Variables
+
+Template variables are defined in `spec.variables` section of the YAML:
+
+```yaml
+spec:
+  variables:
+    - key: PUBLIC_DOMAIN
+      type: DOMAIN
+      name: Domain
+      description: Enter your domain prefix
+    - key: DB_NAME
+      type: STRING
+      name: Database Name
+      description: Database name
+```
+
+To create or edit template YAML files, use the `zeabur-template` skill.
+
+## Known Limitations
+
+### Custom PREBUILT template YAML: internal DNS may not register
+
+Services deployed via custom template YAML files (`-f template.yaml`) with `template: PREBUILT` may not get registered in Zeabur's internal DNS (`*.zeabur.internal`). This means other services in the same project cannot connect to them by hostname. See [zeabur/cli#204](https://github.com/zeabur/cli/issues/204).
+
+**Workaround**: For database services (PostgreSQL, MySQL, Redis), use the marketplace template code (`-c <CODE>`) instead of custom YAML files. Marketplace templates are properly registered in internal DNS.
+
+```bash
+# RECOMMENDED — deploy via marketplace code (has internal DNS)
+npx zeabur@latest template search postgresql -i=false --json
+npx zeabur@latest template deploy -i=false -c <CODE> --project-id <id>
+
+# NOT RECOMMENDED — custom YAML may lack internal DNS
+npx zeabur@latest template deploy -i=false -f my-pg.yaml --project-id <id>
+```
+
+### Custom template YAML schema: `spec` nesting
+
+Template YAML requires `spec.services[].spec.source`, not `spec.services[].source`:
+
+```yaml
+# CORRECT
+spec:
+  services:
+    - name: my-service
+      template: PREBUILT
+      spec:                    # <-- required nesting
+        source:
+          image: postgres:17
+
+# WRONG — will fail with "missing property 'spec'"
+spec:
+  services:
+    - name: my-service
+      template: PREBUILT
+      source:                  # <-- missing spec wrapper
+        image: postgres:17
+```
+
+## Common Issues
+
+| Issue | Solution |
+|-------|----------|
+| Interactive prompt hangs | Always use `-i=false` with `--project-id` and `--var` flags |
+| Missing variables error | Add all required `--var` flags |
+| Variable with `${REF}` | Use literal value or set in Dashboard after deploy |
+| DOMAIN type validation | Domain availability checked automatically |
+| `missing property 'spec'` | Wrap `source`/`ports`/`env` under `spec:` (double-nested) |
+| Other services can't connect to DB | Use marketplace code (`-c`) not custom YAML (`-f`) for databases |
+

--- a/plugins/zeabur/skills/zeabur-template-publish/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-template-publish/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: zeabur-template-publish
+description: Use when publishing or updating a Zeabur template to the marketplace. Use when user says "publish template", "update template online", "push template to Zeabur", or "create template on Zeabur". Do NOT use for deploying templates (use zeabur-template-deploy instead). Do NOT use for editing template YAML (use zeabur-template instead).
+---
+
+# Zeabur Template Publish
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+Publish a template YAML file to the Zeabur marketplace, or update an existing one.
+
+## Create a New Template
+
+```bash
+npx zeabur@latest template create -f <template-file>.yaml
+```
+
+This uploads the YAML and returns a template code (e.g., `VTZ4FX`). Save this code — you'll need it for future updates.
+
+## Update an Existing Template
+
+```bash
+npx zeabur@latest template update -c <TEMPLATE_CODE> -f <template-file>.yaml
+```
+
+The template code is the identifier from the template URL: `https://zeabur.com/templates/<TEMPLATE_CODE>`
+
+## Delete a Template
+
+```bash
+npx zeabur@latest template delete -c <TEMPLATE_CODE>
+```
+
+## Verify
+
+After publishing or updating, check the template page:
+
+```
+https://zeabur.com/templates/<TEMPLATE_CODE>
+```
+
+Or fetch the YAML to confirm:
+
+```bash
+npx zeabur@latest template get -c <TEMPLATE_CODE> --raw
+```
+
+## Flags
+
+### `template create`
+
+| Flag | Description |
+|------|-------------|
+| `-f, --file` | Template YAML file to publish |
+
+### `template update`
+
+| Flag | Description |
+|------|-------------|
+| `-c, --code` | Template code to update |
+| `-f, --file` | Template YAML file with changes |
+
+### `template delete`
+
+| Flag | Description |
+|------|-------------|
+| `-c, --code` | Template code to delete |
+
+## Workflow
+
+```bash
+# First time: create and note the returned code (use the `zeabur-template` skill to create the YAML first)
+npx zeabur@latest template create -f zeabur-template-myapp.yaml
+# → Template created: VTZ4FX
+
+# Later: update with changes
+npx zeabur@latest template update -c VTZ4FX -f zeabur-template-myapp.yaml
+
+# Verify
+npx zeabur@latest template get -c VTZ4FX --raw
+```
+

--- a/plugins/zeabur/skills/zeabur-template/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-template/SKILL.md
@@ -1,0 +1,499 @@
+---
+name: zeabur-template
+description: Use when creating, editing, validating, or troubleshooting a Zeabur template YAML. Use when converting docker-compose to Zeabur template. Do NOT use for deploying templates (use zeabur-template-deploy instead).
+---
+
+# Zeabur Template Knowledge Base
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+This skill provides comprehensive knowledge for creating, debugging, and publishing Zeabur templates. It combines reference documentation with battle-tested patterns from real template development.
+
+## External Documentation
+
+For the latest schema and detailed docs, fetch from `https://raw.githubusercontent.com/zeabur/zeabur-template-doc/main/`:
+
+| User Need | Document to Fetch | Path |
+|-----------|-------------------|------|
+| Create a template from scratch | Step-by-step guide | `docs/GUIDE.md` |
+| Convert docker-compose.yml | Migration guide | `docs/DOCKER_COMPOSE_MIGRATION.md` |
+| Look up YAML fields or built-in variables | Technical reference | `docs/REFERENCE.md` |
+| Naming, design patterns, best practices | Best practices | `docs/BEST_PRACTICES.md` |
+| Debug template errors | Troubleshooting | `docs/TROUBLESHOOTING.md` |
+| Pre-deployment checklist | Checklist | `docs/CHECKLIST.md` |
+| Quick all-in-one overview | Comprehensive prompt | `prompt.md` |
+
+The template YAML schema is also available at https://schema.zeabur.app/template.json and the prebuilt service schema at https://schema.zeabur.app/prebuilt.json.
+
+---
+
+## Core Principles
+
+### 0. All services MUST use PREBUILT_V2 with Docker images
+
+**Every service in a template MUST be `template: PREBUILT_V2` with a Docker image as the source.** Never use `template: GIT`, `ARBITRARY_GIT`, or `GITHUB` source — these are NOT supported in templates.
+
+If the project does not have a published Docker image (on Docker Hub, GHCR, etc.), **tell the user they need to build and publish a Docker image first** before a template can be created. Do not attempt to work around this.
+
+If the user asks you to build the image, follow this workflow:
+1. Clone the project repo and find its `Dockerfile` (usually at repo root)
+2. Study the Dockerfile to understand build stages — use the **production stage** (often named `runner` or `production`)
+3. Study `docker-compose.yml` or `docker-compose.fullapp.yml` for the correct startup command, env vars, and volumes — this is the battle-tested production config
+4. Build for **amd64** (Zeabur servers are amd64, local Macs are arm64):
+   ```bash
+   docker buildx build --platform linux/amd64 --target runner -t org/image:tag --push .
+   ```
+5. After pushing, **verify the Docker Hub repo is public**:
+   ```bash
+   curl -s "https://hub.docker.com/v2/repositories/ORG/IMAGE/" | grep is_private
+   ```
+   New repos under org accounts often default to private. If `is_private: true`, the user must make it public on Docker Hub.
+
+### 1. Never start from scratch
+
+When asked to create a template, **always** look for existing configuration first:
+- **First check if a Docker image exists** — search Docker Hub, GHCR (`ghcr.io/org/repo`), or the project's CI/CD for published images. If none exists, stop and inform the user.
+- Search for the project's `docker-compose.yml`, `docker-compose.yaml`, or `compose.yml`
+- Look for Helm charts (`Chart.yaml`, `values.yaml`)
+- Check the project's GitHub repo for any deployment YAML files
+- Use these as the foundation to build the Zeabur template, not as a loose reference — they contain battle-tested environment variables, port mappings, volume mounts, and service dependencies
+
+### 2. Iterate via runtime logs — never expect one-shot success
+
+Even experienced humans cannot create a working template in one shot. The workflow is an **iterative loop**:
+
+1. Write/update the template YAML
+2. Deploy the template
+3. It will likely fail — check runtime logs to find the cause
+4. Fix the issue in the template
+5. Delete the project and redeploy from scratch
+6. Repeat until the template achieves **one-click deployment success**
+
+This is the normal process, not a sign of failure. Do not try to get everything perfect before deploying — deploy early, read logs, and iterate.
+
+### 3. Reuse from existing templates — never write common services from scratch
+
+When your template needs a common service (PostgreSQL, Redis, MySQL, MongoDB, etc.), **do not write the service definition yourself**. Instead:
+
+1. Search for existing templates that already use that service:
+   ```bash
+   npx zeabur@latest template search postgres
+   ```
+2. Find a template that includes the service you need
+3. Get the raw template YAML to see the exact service definition:
+   ```bash
+   npx zeabur@latest template get -c TEMPLATE_CODE --raw
+   ```
+4. Copy the service definition directly from that template into yours
+
+**How to judge template trustworthiness:**
+- Many templates are created by regular users and may not work correctly
+- **Prefer templates with more deployments** — higher deployment count = more battle-tested
+- **Prefer official templates over user-submitted ones** — official templates are vetted by Zeabur team
+
+---
+
+## CLI Commands for the Iteration Loop
+
+**Deploy a template:**
+```bash
+npx zeabur@latest template deploy -f YOUR_TEMPLATE.yaml
+```
+For non-interactive mode (automation):
+```bash
+npx zeabur@latest template deploy -i=false \
+  -f YOUR_TEMPLATE.yaml \
+  --project-id PROJECT_ID \
+  --var PUBLIC_DOMAIN=myapp
+```
+
+**List services (to get SERVICE_ID):**
+```bash
+npx zeabur@latest service list --project-id PROJECT_ID
+```
+
+**Check runtime logs:**
+```bash
+npx zeabur@latest deployment log --service-id SERVICE_ID
+```
+
+**Execute a command inside a running service** (like `docker exec`):
+```bash
+npx zeabur@latest service exec --id SERVICE_ID -- SHELL_COMMAND
+```
+This is extremely useful for debugging — check file paths, env vars, test connectivity, inspect the filesystem, etc. Examples:
+```bash
+npx zeabur@latest service exec --id SERVICE_ID -- ls /app
+npx zeabur@latest service exec --id SERVICE_ID -- env | grep DATABASE
+npx zeabur@latest service exec --id SERVICE_ID -- nc -z localhost 5432
+```
+
+**Restart a service** (useful to clear ImagePullBackOff or force re-pull):
+```bash
+npx zeabur@latest service restart --id SERVICE_ID -i=false -y
+```
+
+**Delete the project and start over:**
+```bash
+npx zeabur@latest project delete --id PROJECT_ID
+```
+> **DANGEROUS OPERATION** — Before deleting a project, you MUST ask the user for explicit confirmation, clearly stating the Project ID, Name, and createdAt timestamp. Never delete without confirmation.
+
+**Publish a new template:**
+```bash
+npx zeabur@latest template create -f YOUR_TEMPLATE.yaml
+```
+This returns a template URL like `https://zeabur.com/templates/XXXXXX` with a template code.
+
+**Update an existing template:**
+```bash
+npx zeabur@latest template update -c TEMPLATE_CODE -f YOUR_TEMPLATE.yaml
+```
+
+---
+
+## Quick Reference: Template Skeleton
+
+```yaml
+# yaml-language-server: $schema=https://schema.zeabur.app/template.json
+apiVersion: zeabur.com/v1
+kind: Template
+metadata:
+  name: ServiceName
+spec:
+  description: |
+    English description (1-3 sentences)
+  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/service.svg
+  coverImage: https://example.com/cover.webp
+  tags:
+    - Category
+  variables: []
+  readme: |
+    # Service Name
+    English documentation...
+  services:
+    - name: service-name
+      icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/service.svg
+      template: PREBUILT_V2
+      spec:
+        source:
+          image: image:tag
+          command:              # MUST be inside source, alongside image
+            - /bin/sh
+            - -c
+            - /opt/app/startup.sh
+        ports:
+          - id: web
+            port: 8080
+            type: HTTP
+        portForwarding:
+          enabled: true        # Auto-expose TCP/UDP ports externally (default: true)
+        healthCheck:              # ensures port is ready before dependents start
+          type: TCP
+          port: web               # references the port ID above
+        volumes:
+          - id: data
+            dir: /path/to/data
+        configs:
+          - path: /opt/app/startup.sh
+            permission: 493     # 0755
+            envsubst: false
+            template: |
+              #!/bin/sh
+              exec node server.js
+        env:
+          VAR_NAME:
+            default: value
+            expose: true
+localization:
+  zh-TW:
+    description: ...
+    variables: []
+    readme: |
+      # ...
+  zh-CN:
+    description: ...
+    variables: []
+    readme: |
+      # ...
+  ja-JP:
+    description: ...
+    variables: []
+    readme: |
+      # ...
+  es-ES:
+    description: ...
+    variables: []
+    readme: |
+      # ...
+  id-ID:
+    description: ...
+    variables: []
+    readme: |
+      # ...
+```
+
+## Quick Reference: Built-in Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `${PASSWORD}` | Auto-generated secure password |
+| `${ZEABUR_WEB_URL}` | Full public URL (e.g. `https://app.zeabur.app`) |
+| `${ZEABUR_WEB_DOMAIN}` | Domain only (e.g. `app.zeabur.app`) |
+| `${CONTAINER_HOSTNAME}` | Internal hostname for inter-service communication |
+| `${[PORTID]_PORT}` | Port value by port ID (e.g. `${DATABASE_PORT}`) |
+| `${PORT_FORWARDED_HOSTNAME}` | External hostname for port forwarding (auto-set when enabled, usable in env vars and `instructions`) |
+| `${[PORTID]_PORT_FORWARDED_PORT}` | External forwarded port number (auto-set when enabled, usable in env vars and `instructions`) |
+
+The `ZEABUR_<PORT_ID>_URL` pattern: for a port named `web`, it becomes `${ZEABUR_WEB_URL}`; for `console`, it becomes `${ZEABUR_CONSOLE_URL}`.
+
+## Quick Reference: command Placement
+
+**IMPORTANT: `command` MUST be inside `source`, alongside `image`. NOT at `spec` level.**
+
+```yaml
+# WRONG -- command at spec level (will be IGNORED, container uses default CMD)
+spec:
+  source:
+    image: python:3.12-slim
+  command:
+    - /bin/sh
+    - -c
+    - /opt/app/start.sh
+
+# CORRECT -- command inside source
+spec:
+  source:
+    image: python:3.12-slim
+    command:
+      - /bin/sh
+      - -c
+      - /opt/app/start.sh
+```
+
+> **Note:** The external docs may show `command` at `spec` level. This is incorrect. Always place `command` inside `source` as confirmed by the JSON schema at `schema.zeabur.app/prebuilt.json`.
+
+## Quick Reference: YAML Gotchas
+
+```yaml
+# RISKY -- @ at start of value is a YAML reserved indicator (may cause parse errors)
+description: @BotFather token
+
+# SAFE -- quote the value or avoid @ at start
+description: "Token from @BotFather for Telegram bot"
+description: Telegram bot token from BotFather
+```
+
+## Quick Reference: Docker Image ENTRYPOINT
+
+**Some base images have ENTRYPOINT set, which conflicts with `command`.**
+
+| Image | ENTRYPOINT | Problem |
+|-------|-----------|---------|
+| `ghcr.io/astral-sh/uv:python3.12-*` | `uv` | `command` becomes args to `uv`, container shows `uv help` and exits |
+| `node:*` | none | Safe to use |
+| `python:*` | none | Safe to use |
+
+If using an image with ENTRYPOINT, switch to a plain base image (e.g. `python:3.12-slim-bookworm`) or one without ENTRYPOINT.
+
+## Quick Reference: TCP Services (proxy, database, game server, etc.)
+
+Services that are NOT web apps — such as HTTP proxies (Tinyproxy, Squid), databases, game servers, VPN servers, or any service that clients connect to directly via TCP/UDP — should **NOT** use HTTP port type or `domainKey`. Instead:
+
+1. **Use `type: TCP` (or `UDP`)** — this prevents Zeabur's reverse proxy (Ingress) from intercepting traffic
+2. **Set `portForwarding: enabled: true`** — this auto-exposes the port externally so clients can connect directly
+3. **Do NOT use `domainKey`** — TCP services don't need a domain; users connect via the forwarded hostname:port
+
+```yaml
+# CORRECT -- TCP service (e.g. HTTP proxy, database, game server)
+spec:
+  source:
+    image: some/tcp-service:latest
+  ports:
+    - id: proxy
+      port: 8888
+      type: TCP          # NOT HTTP — clients connect directly
+  portForwarding:
+    enabled: true        # Auto-expose this port externally
+  env:
+    # ...
+
+# WRONG -- using HTTP type for a TCP proxy
+spec:
+  ports:
+    - id: proxy
+      port: 8888
+      type: HTTP         # Zeabur's Ingress will intercept CONNECT requests
+  # Missing portForwarding — users must manually enable in Dashboard
+```
+
+**Why not HTTP?** Zeabur's HTTP port type routes traffic through a reverse proxy (Ingress/Envoy) that terminates TLS and performs Host-based routing. This breaks protocols like HTTP CONNECT (used by proxies), raw TCP streams (databases), and custom binary protocols (game servers).
+
+**Port Forwarding variables** (for use in `instructions` or readme):
+- `${PORT_FORWARDED_HOSTNAME}` — the external hostname
+- `${PROXY_PORT_FORWARDED_PORT}` — the external port (pattern: `${[PORTID]_PORT_FORWARDED_PORT}`)
+
+**Post-deployment testing for TCP services:**
+
+After deploying a TCP service, verify port forwarding is working:
+
+1. Check internal connectivity first (from inside the container):
+   ```bash
+   npx zeabur@latest service exec --id SERVICE_ID -- curl -x http://127.0.0.1:8888 https://ifconfig.co
+   ```
+
+2. Get the forwarded host:port from the Dashboard's **Networking** tab, or use:
+   ```bash
+   npx zeabur@latest service network --id SERVICE_ID
+   ```
+
+3. Test external connectivity:
+   ```bash
+   curl -x http://FORWARDED_HOST:FORWARDED_PORT https://ifconfig.co
+   ```
+
+If port forwarding shows as DISABLED, enable it:
+```bash
+npx zeabur@latest service port-forward --id SERVICE_ID --enable
+```
+
+## Quick Reference: Headless Services (no HTTP)
+
+If a service does NOT listen on any HTTP port (502 Bad Gateway), see `zeabur-port-mismatch` skill for the fix.
+
+## Quick Reference: Critical Rules
+
+```yaml
+# WRONG -- using :latest tag (may serve cached/stale image)
+image: rajnandan1/kener:latest
+
+# CORRECT -- pin to specific version
+image: rajnandan1/kener:4.0.16
+
+# WRONG -- hardcoded password
+POSTGRES_PASSWORD:
+  default: mypassword123
+
+# CORRECT -- use ${PASSWORD}
+POSTGRES_PASSWORD:
+  default: ${PASSWORD}
+  expose: true
+
+# WRONG -- PUBLIC_DOMAIN gives incomplete URL
+APP_URL:
+  default: https://${PUBLIC_DOMAIN}
+
+# CORRECT -- ZEABUR_WEB_URL gives full URL
+APP_URL:
+  default: ${ZEABUR_WEB_URL}
+  readonly: true
+
+# WRONG -- other services can't reference without expose
+POSTGRES_HOST:
+  default: ${CONTAINER_HOSTNAME}
+
+# CORRECT -- expose + readonly for connection info
+POSTGRES_HOST:
+  default: ${CONTAINER_HOSTNAME}
+  expose: true
+  readonly: true
+
+# WRONG -- referencing variables without declaring dependency
+- name: app
+  spec:
+    env:
+      DB: ${POSTGRES_HOST}
+
+# CORRECT -- declare dependency first
+- name: app
+  dependencies:
+    - postgresql
+  spec:
+    env:
+      DB: ${POSTGRES_HOST}
+
+# WRONG -- HTTP type for a TCP proxy/database/game server
+ports:
+  - id: proxy
+    port: 8888
+    type: HTTP
+
+# CORRECT -- TCP type + portForwarding for non-web services
+ports:
+  - id: proxy
+    port: 8888
+    type: TCP
+portForwarding:
+  enabled: true
+```
+
+---
+
+## Domain Binding
+
+Use `domainKey` on the service that needs a public domain. It maps to a variable defined in `spec.variables` with `type: DOMAIN`.
+
+**Single domain:**
+```yaml
+domainKey: PUBLIC_DOMAIN
+```
+
+**Multiple domains (different ports):**
+```yaml
+domainKey:
+    - port: web
+      variable: ENDPOINT_DOMAIN
+    - port: console
+      variable: ADMIN_ENDPOINT_DOMAIN
+```
+
+---
+
+## Common Database Configs
+
+See `references/database-configs.md` for copy-paste PostgreSQL, MySQL/MariaDB, Redis configs and standard volume paths.
+
+---
+
+## Template Complexity Levels
+
+See `references/complexity-levels.md` for the 5-level complexity guide (single service → large-scale multi-service platform).
+
+---
+
+## Writing name, description, readme, icon, and coverImage
+
+**Where to collect information** (in priority order):
+1. The project's **GitHub repo README**
+2. The project's **official website**
+3. Other **public sources** (blog posts, documentation sites, etc.)
+
+**Key rules:**
+1. **Do NOT copy-paste the original README.** Write the introduction for **this project's Zeabur template**, not for the project itself. The readme should:
+   - Briefly introduce what the project is
+   - Focus on how to use this template (deployment steps, configuration, domain binding)
+   - Include important caveats and troubleshooting tips specific to Zeabur deployment
+2. **Always include licensing and attribution.** If the original project has an MIT, Apache, or other license:
+   - Mention the license in the readme
+   - Link to the original repo
+   - Link to the official website if available
+   - This is **legally required** -- never skip it
+3. **icon and coverImage**: Find the project's logo from their GitHub repo or official website. Use a direct URL to an image (SVG, PNG, or WebP). **Always verify the URL returns HTTP 200**:
+   ```bash
+   curl -s -o /dev/null -w "%{http_code}" "URL"
+   ```
+   Common pitfall: wrong branch name in `raw.githubusercontent.com` URLs (`develop` vs `main` vs `master`).
+
+## Localization Requirements
+
+6 languages required: en-US (in `spec`), zh-TW, zh-CN, ja-JP, es-ES, id-ID.
+
+**Translate:** `description`, `variables[].name`, `variables[].description`, `readme`
+
+**Do NOT translate:** `key`, `type`, `${VARIABLE_NAMES}`, URLs
+
+---
+
+## Hard-Won Lessons
+
+See `references/hard-won-lessons.md` for battle-tested patterns: wait-for-db, first-run init markers, OOM recovery, ImagePullBackOff, and more.

--- a/plugins/zeabur/skills/zeabur-template/references/complexity-levels.md
+++ b/plugins/zeabur/skills/zeabur-template/references/complexity-levels.md
@@ -1,0 +1,24 @@
+# Template Complexity Levels
+
+**Level 1 -- Single prebuilt service** (e.g., Memos, Uptime-Kuma, LobeChat):
+- Just one service with image, port, and optionally a volume
+- Simplest pattern, no cross-service wiring needed
+
+**Level 2 -- App + database** (e.g., Ghost+MySQL, Linkwarden+PostgreSQL):
+- Database service exposes vars, app service references them
+- App service uses `dependencies` to ensure DB starts first
+
+**Level 3 -- App + database + init/migrator** (e.g., Teable, Open Mercato):
+- First-run initialization or separate migrator service
+- Requires wait-for-db pattern and init marker files
+
+**Level 4 -- Multi-service with multiple domains** (e.g., Logto):
+- Multiple ports on one service, each bound to a different domain variable
+
+**Level 5 -- Large-scale multi-service platform** (e.g., Dify 12 services, Supabase 11 services):
+- **Reverse proxy as entry point**: nginx (Dify) or Kong (Supabase) as the single domain-bound service
+- **Same image, different MODE**: e.g., Dify runs `api`, `worker`, `worker-beat` from the same image
+- **Internal-only services**: no public domain, communicate via `${CONTAINER_HOSTNAME}`
+- **Heavy use of `configs`**: Nginx conf, SQL init scripts, Kong config — all injected via `configs` field
+- **PostgreSQL init SQL via configs**: Mount to `/docker-entrypoint-initdb.d/` for auto execution
+- **Shared secrets**: Use `${PASSWORD}` for all internal credentials

--- a/plugins/zeabur/skills/zeabur-template/references/database-configs.md
+++ b/plugins/zeabur/skills/zeabur-template/references/database-configs.md
@@ -1,0 +1,111 @@
+# Common Database Configs
+
+### PostgreSQL
+
+```yaml
+- name: postgresql
+  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/postgresql.svg
+  template: PREBUILT_V2
+  spec:
+    source:
+      image: postgres:16-alpine
+    ports:
+      - id: database
+        port: 5432
+        type: TCP
+    volumes:
+      - id: data
+        dir: /var/lib/postgresql/data
+    env:
+      POSTGRES_USER:
+        default: postgres
+        expose: true
+      POSTGRES_PASSWORD:
+        default: ${PASSWORD}
+        expose: true
+      POSTGRES_DB:
+        default: mydb
+        expose: true
+      POSTGRES_HOST:
+        default: ${CONTAINER_HOSTNAME}
+        expose: true
+        readonly: true
+      POSTGRES_PORT:
+        default: ${DATABASE_PORT}
+        expose: true
+        readonly: true
+      POSTGRES_CONNECTION_STRING:
+        default: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
+        expose: true
+        readonly: true
+```
+
+### MySQL/MariaDB
+
+```yaml
+- name: mariadb
+  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/mariadb.svg
+  template: PREBUILT_V2
+  spec:
+    source:
+      image: mariadb:10.6
+    ports:
+      - id: database
+        port: 3306
+        type: TCP
+    volumes:
+      - id: data
+        dir: /var/lib/mysql
+    env:
+      MYSQL_ROOT_PASSWORD:
+        default: ${PASSWORD}
+        expose: true
+      MYSQL_DATABASE:
+        default: mydb
+        expose: true
+      MYSQL_HOST:
+        default: ${CONTAINER_HOSTNAME}
+        expose: true
+        readonly: true
+      MYSQL_PORT:
+        default: ${DATABASE_PORT}
+        expose: true
+        readonly: true
+```
+
+### Redis
+
+```yaml
+- name: redis
+  icon: https://raw.githubusercontent.com/zeabur/service-icons/main/marketplace/redis.svg
+  template: PREBUILT_V2
+  spec:
+    source:
+      image: redis:7-alpine
+    ports:
+      - id: database
+        port: 6379
+        type: TCP
+    volumes:
+      - id: data
+        dir: /data
+    env:
+      REDIS_HOST:
+        default: ${CONTAINER_HOSTNAME}
+        expose: true
+        readonly: true
+      REDIS_PORT:
+        default: ${DATABASE_PORT}
+        expose: true
+        readonly: true
+```
+
+### Standard Volume Paths
+
+| Service | Path |
+|---------|------|
+| PostgreSQL | `/var/lib/postgresql/data` |
+| MySQL/MariaDB | `/var/lib/mysql` |
+| MongoDB | `/data/db` |
+| Redis | `/data` |
+| MinIO | `/data` |

--- a/plugins/zeabur/skills/zeabur-template/references/hard-won-lessons.md
+++ b/plugins/zeabur/skills/zeabur-template/references/hard-won-lessons.md
@@ -1,0 +1,108 @@
+# Hard-Won Lessons (from real template challenges)
+
+##Wait for database readiness
+Zeabur's `dependencies` field only ensures services are **deployed**, not that they're **ready to accept connections**. A database container can take 5-15 seconds to initialize.
+
+**Preferred approach: `healthCheck`** — add a health check to the dependency service so Zeabur waits until the port is ready before starting dependent services:
+```yaml
+- name: postgresql
+  spec:
+    ports:
+      - id: database
+        port: 5432
+        type: TCP
+    healthCheck:
+      type: TCP
+      port: database    # references the port ID
+```
+This is cleaner than wait loops and requires no changes to the app's startup command.
+
+**Fallback: wait loop** — if you can't modify the template, add a wait loop to the app's command:
+```yaml
+args:
+    - -c
+    - |
+        echo "Waiting for PostgreSQL..."
+        while ! nc -z ${POSTGRES_HOST} ${POSTGRES_PORT} 2>/dev/null; do sleep 2; done
+        echo "PostgreSQL is ready!"
+        # ... then run migrations/init
+```
+Note: `nc` (netcat) is available on most Alpine-based images. If not, use `wget --spider` or a node one-liner.
+
+##Pin image tags — never use `latest`
+Always pin Docker images to a specific version tag (e.g., `rajnandan1/kener:4.0.16`). Never use `:latest` in templates because:
+- Zeabur's registry may cache an old version of `latest`, causing users to deploy stale or broken images
+- Upstream breaking changes silently affect all new deployments
+- Debugging becomes harder when you don't know which version is running
+
+When the upstream releases a new version, update the template with the new pinned tag and test before publishing.
+
+##Study the project's own Dockerfile and docker-compose
+**Never guess startup commands.** Instead:
+1. Read the project's `Dockerfile` to understand the build stages and the final `CMD`/`ENTRYPOINT`
+2. Read `docker-compose.yml` and especially `docker-compose.fullapp.yml` (or `docker-compose.prod.yml`) for the production startup command -- these often override the Dockerfile's CMD with init/migrate logic
+3. Check the app's `package.json` scripts to understand what `yarn start` or `npm start` actually runs
+4. The startup command in docker-compose is battle-tested -- copy it, don't reinvent it
+
+##Memory-heavy apps need lighter startup
+Apps that spawn workers, schedulers, and the web server all in one process may OOM on Zeabur's default allocation. Signs of OOM:
+- Container starts, runs for 1-2 minutes, then crashes with no error logs (just `BackOff: Back-off restarting failed container`)
+- No application-level crash message -- the kernel kills the process silently
+
+Solutions:
+- Run the web server directly (e.g., `next start` or `node server.js`) instead of a CLI wrapper that spawns workers + scheduler + server
+- Disable non-essential background processes via env vars (e.g., `AUTO_SPAWN_WORKERS=false`)
+- If workers are needed, consider splitting them into a separate service
+
+##First-run init with persistent marker
+For apps that need first-time initialization (DB schema, seed data, admin users), use a marker file in a persistent volume:
+```yaml
+args:
+    - -c
+    - |
+        if [ ! -f /app/storage/.initialized ]; then
+          echo "First run: initializing..."
+          run-init-command && touch /app/storage/.initialized
+        else
+          echo "Subsequent run: migrations only..."
+          run-migrate-command
+        fi
+        exec start-server-command
+```
+Key points:
+- The marker file MUST be in a **persistent volume**, not `/tmp/` (which is ephemeral)
+- Use `&&` after init so the marker is only created if init succeeds
+- Use `exec` for the final server process so it becomes PID 1 and receives signals properly
+- Read init logs carefully for the **actual default credentials** -- don't assume from docs
+
+##Working directory matters
+When overriding `command`/`args`, be aware of the Dockerfile's `WORKDIR`. In monorepo apps, different commands need to run from different directories:
+```yaml
+args:
+    - -c
+    - |
+        cd /app              # root workspace for yarn workspace commands
+        yarn mercato init    # CLI from root package.json
+        cd /app/apps/myapp   # app directory for next start
+        exec next start -p 3000
+```
+
+##ImagePullBackOff recovery
+When a pod is stuck in `ImagePullBackOff` (e.g., after making a Docker Hub repo public), the Kubernetes backoff timer prevents immediate retries. Fix by restarting the service:
+```bash
+npx zeabur@latest service restart --id SERVICE_ID -i=false -y
+```
+
+##Disable unused monitoring agents
+Many production images ship with New Relic, Datadog, or similar APM agents. These require license keys and consume memory. Add `NEW_RELIC_ENABLED=false` or equivalent env vars to disable them cleanly. Check if the `start` script injects agents via `NODE_OPTIONS='-r newrelic'` -- these still run even if the agent errors out.
+
+##Verify all URLs before publishing
+Before publishing a template, verify that ALL URLs return HTTP 200:
+- `icon` URL
+- `coverImage` URL
+- Links in `readme`
+
+Common pitfall: `raw.githubusercontent.com` URLs with wrong branch name (`develop` vs `main` vs `master`). Always check:
+```bash
+curl -s -o /dev/null -w "%{http_code}" "https://raw.githubusercontent.com/..."
+```

--- a/plugins/zeabur/skills/zeabur-update-service/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-update-service/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: zeabur-update-service
+description: Use when modifying service config without full redeploy. Use when updating env vars and restarting single service. Use when user says "change env var", "update config", "fix variable without redeploying", "upgrade service version", "update image tag", or "change service tag".
+---
+
+# Zeabur Update Service Without Redeploy
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+
+## Workflow
+
+```bash
+# 1. Get service ID (use the `zeabur-service-list` skill)
+npx zeabur@latest service list --project-id <project-id> -i=false
+
+# 2. Check current variables
+npx zeabur@latest variable list --id <service-id> -i=false
+
+# 3a. Add new variables (errors if key already exists)
+npx zeabur@latest variable create --id <service-id> \
+  --key "KEY1=value1" \
+  --key "KEY2=value2" \
+  -i=false -y
+
+# 3b. Update existing variables (only updates specified keys)
+npx zeabur@latest variable update --id <service-id> \
+  --key "KEY1=new_value1" \
+  -i=false -y
+
+# 4. Restart service (use the `zeabur-restart` skill for details)
+npx zeabur@latest service restart --id <service-id> -y -i=false
+```
+
+## Caveats
+
+| Issue | Solution |
+|-------|----------|
+| `${VAR}` references | Set in Dashboard, not CLI (shell expands to empty) |
+
+## Update Image Tag (Upgrade / Downgrade Service Version)
+
+For prebuilt/marketplace services, update the image tag to switch versions.
+
+> **This is the ONLY correct path for version upgrades or downgrades.** Do NOT use `zeabur-deploy` (or any redeploy / delete-and-recreate flow) as a substitute — those flows can orphan or wipe the service's mounted disk. A tag update triggers a clean redeploy with the new image while the volume stays attached.
+
+### Workflow
+
+```bash
+# 1. Get service ID (use the `zeabur-service-list` skill)
+npx zeabur@latest service list --project-id <project-id> -i=false
+
+# 2. Update tag (triggers redeploy automatically)
+npx zeabur@latest service update tag --id <service-id> -t <new-tag> -y -i=false
+```
+
+### Flags
+
+| Flag | Description |
+|------|-------------|
+| `--id` | Service ID (**required**, do not use `--name`) |
+| `-t, --tag` | New image tag to deploy |
+| `--env-id` | Environment ID (optional, resolved automatically) |
+| `-y, --yes` | Skip confirmation |
+
+> **Note:** Updating the tag triggers a new deployment. The service will restart with the updated image.
+
+## When to Use
+
+- Fix environment variable typos
+- Add missing config
+- Change ports, URLs, credentials
+- Upgrade a prebuilt service to a newer version
+- **No need to redeploy entire template**
+

--- a/plugins/zeabur/skills/zeabur-variables/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-variables/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: zeabur-variables
+description: Use for ALL Zeabur environment variable operations — create, list, update, delete, or troubleshoot. Use when user says "set env var", "add variable", "create variable", "update variable", "delete variable", "change env var", or "why is my variable empty". Also use when variables are empty or SERVICE_NOT_FOUND errors.
+---
+
+# Zeabur Variables Management
+
+> **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
+>
+> **Do not guess CLI syntax.** Only `create`, `update`, `delete`, `env`, and `list` are valid subcommands. Subcommands like `set` or `add` do not exist and will silently fail with no error output.
+
+## Known Issues
+
+1. **Use `--id` not `--name`** — name lookup is unreliable
+2. **`${VAR}` gets empty** — shell expands before CLI receives; use single quotes
+3. **`variable env` replaces ALL variables** — it overwrites the entire variable set with the .env file contents; existing variables not in the file will be removed
+
+## Create Variables
+
+Creates new variables. **Errors if a key already exists** — use `update` to change existing keys.
+
+```bash
+# Always use service ID — use the `zeabur-service-list` skill to get it
+npx zeabur@latest variable create --id <service-id> \
+  -k "KEY1=value1" \
+  -k "KEY2=value2" \
+  -y -i=false
+```
+
+## Update Variables
+
+Updates only the specified keys. **Does NOT clear other variables.**
+
+```bash
+npx zeabur@latest variable update --id <service-id> \
+  -k "KEY1=new_value1" \
+  -k "KEY2=new_value2" \
+  -y -i=false
+```
+
+## Delete Variables
+
+Deletes only the specified keys.
+
+```bash
+npx zeabur@latest variable delete --id <service-id> \
+  --delete-keys "KEY1" \
+  --delete-keys "KEY2" \
+  -y -i=false
+```
+
+## List Variables
+
+```bash
+npx zeabur@latest variable list --id <service-id> -i=false
+```
+
+## Load from .env File
+
+> **Warning:** This **replaces ALL variables** on the service with the contents of the .env file. Existing variables not in the file will be removed.
+
+```bash
+npx zeabur@latest variable env --id <service-id> -f .env
+```
+
+After running `env`, you must restart the service manually to apply changes.
+
+## Variable References
+
+> **Warning:** The CLI `-k` flag uses Cobra's `StringToStringVar` parser which cannot reliably handle values containing `${}`, even with single quotes. The value may be truncated or emptied. See [zeabur/cli#201](https://github.com/zeabur/cli/issues/201).
+
+```bash
+# WRONG — shell expands ${VAR} to empty
+npx zeabur@latest variable create --id <service-id> -k "REDIS_URL=${REDIS_URI_INTERNAL}" -y -i=false
+
+# STILL UNRELIABLE — single quotes prevent shell expansion but Cobra's CSV parser may still mangle the value
+npx zeabur@latest variable create --id <service-id> -k 'REDIS_URL=${REDIS_URI_INTERNAL}' -y -i=false
+
+# RECOMMENDED — set variable references in Zeabur Dashboard
+# Or use GraphQL API with updateEnvironmentVariable(data: Map!) mutation
+```
+
+For cross-service variable references like `${POSTGRES_CONNECTION_STRING}` (Zeabur uses a flat namespace — all exposed variables from other services are merged directly, no service prefix needed), **always use the Zeabur Dashboard** until the CLI bug is fixed.
+
+## Quick Reference
+
+| Need | Command | Behavior |
+|------|---------|----------|
+| Add new vars | `npx zeabur@latest variable create --id <service-id> -k "K=V" -y -i=false` | Errors if key exists |
+| Change existing vars | `npx zeabur@latest variable update --id <service-id> -k "K=V" -y -i=false` | Only updates specified keys |
+| Remove specific vars | `npx zeabur@latest variable delete --id <service-id> --delete-keys "K" -y -i=false` | Only removes specified keys |
+| Overwrite all vars from file | `npx zeabur@latest variable env --id <service-id> -f .env` | **Replaces entire variable set** |
+| View vars | `npx zeabur@latest variable list --id <service-id> -i=false` | Read-only |
+

--- a/scripts/sync-codex-plugin.mjs
+++ b/scripts/sync-codex-plugin.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// Generates plugins/zeabur/ (the Codex plugin) from the canonical root skills/.
+//
+// Why this exists: Codex's plugin marketplace requires the plugin to live in a
+// SUBDIRECTORY with its skills physically inside it — it cannot point at the repo
+// root, and it does not follow symlinks or "../" paths when copying to its cache.
+// Meanwhile the root skills/ must stay put because Claude's plugin is the repo root
+// and zeabur.com reads zeabur-claude-plugin/skills via a submodule. So plugins/zeabur/
+// is a GENERATED mirror of root skills/ — edit skills in root only, then re-run this.
+//
+// Usage: node scripts/sync-codex-plugin.mjs
+// CI verifies the committed output matches (see .github/workflows/codex-plugin-sync.yml).
+
+import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const out = path.join(root, 'plugins', 'zeabur');
+
+await rm(out, { recursive: true, force: true });
+await mkdir(path.join(out, '.codex-plugin'), { recursive: true });
+
+// Mirror the canonical skills into the Codex plugin directory.
+await cp(path.join(root, 'skills'), path.join(out, 'skills'), { recursive: true });
+
+// Reuse the root Codex plugin manifest; its skills path ("./skills/") already
+// resolves correctly relative to the plugin directory.
+const manifest = JSON.parse(
+  await readFile(path.join(root, '.codex-plugin', 'plugin.json'), 'utf8'),
+);
+manifest.skills = './skills/';
+await writeFile(
+  path.join(out, '.codex-plugin', 'plugin.json'),
+  JSON.stringify(manifest, null, 2) + '\n',
+);
+
+console.log('Synced plugins/zeabur/ from root skills/ and .codex-plugin/plugin.json');


### PR DESCRIPTION
## What

Makes the official Codex install flow work:

```
codex plugin marketplace add zeabur/agent-skills
codex plugin add zeabur@zeabur
```

Before this, `codex plugin add zeabur@zeabur` failed with `plugin not found` (the marketplace resolved to **0 plugins**).

## Why it was broken

Verified with codex-cli 0.140.0:

1. The repo only had `.claude-plugin/marketplace.json` (Claude's string-source format). Codex reads this file but can't parse the plugin entry, so it found no plugins.
2. A Codex marketplace plugin **cannot reference the repo root** — see [openai/codex#17066](https://github.com/openai/codex/issues/17066). It must live in a subdirectory.
3. Skills must be **physically inside** the plugin directory — Codex copies only the plugin subdir to its cache (symlinks / `../` paths don't survive).

## Approach

Root `skills/` stays the single source of truth (Claude's plugin is the repo root, and zeabur.com reads `agent-skills/skills` via submodule — neither can move). `plugins/zeabur/` is a **generated** Codex mirror:

- `.agents/plugins/marketplace.json` — Codex marketplace, points at `./plugins/zeabur`
- `plugins/zeabur/` — generated: `.codex-plugin/plugin.json` + copy of root skills
- `scripts/sync-codex-plugin.mjs` — regenerates `plugins/zeabur/` from root `skills/`
- `.github/workflows/codex-plugin-sync.yml` — CI fails if the two drift

This matches the convention used by [`openai/role-specific-plugins`](https://github.com/openai/role-specific-plugins) and [`jup-ag/agent-skills`](https://github.com/jup-ag/agent-skills) (root skills + generated per-agent plugin subdir + sync script).

## Verification

End-to-end with codex-cli 0.140.0 on this branch's contents:

- `codex plugin marketplace add <repo>` → marketplace added
- `codex plugin add zeabur@zeabur` → **installed all 32 skills, enabled: true**
- Root `.claude-plugin/` and `skills/` untouched → Claude + zeabur.com unaffected

## Maintenance

Edit skills in root `skills/` only, then run `node scripts/sync-codex-plugin.mjs`. CI enforces this.

Linear: DES-742

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785002149&installation_id=128583772&pr_number=70&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F70&signature=9fc3e84d486a4786f642da106efb6d2437a45bf1a0ad03096a8f5855fbcdf11d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new Zeabur marketplace plugin entry, along with refreshed plugin metadata (including the latest version).
  * Introduced extensive new Zeabur skill documentation covering deployment workflows, templates, domains (DNS/registration/URLs), databases, object storage, servers, variables, authentication, email, Dockerfile generation, and common troubleshooting (logs, metrics, port mismatches, startup order, restarts).
* **Chores**
  * Added an automated sync check that regenerates the Codex plugin content on pushes and pull requests, failing if generated output is out of date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->