### PR TITLE
docs(skills): require explicit priced confirmation before server rent

### DIFF
--- a/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
@@ -7,6 +7,26 @@ description: Use when renting a new dedicated server. Use when user wants to buy
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
 
+## ⚠️ Renting charges real money — explicit confirmation is REQUIRED
+
+`server rent` immediately charges the user's payment method (or Zeabur balance). The `-y` flag skips the CLI's own confirmation prompt, so **you are the last line of defense**: never run `server rent` until the user has explicitly confirmed the exact priced option.
+
+Before renting, you MUST present all of the following to the user in one message:
+
+- **Provider** (e.g. DigitalOcean)
+- **Region** (e.g. New York / `nyc3`)
+- **Plan/spec** (e.g. `s-2vcpu-4gb` — 2 vCPU / 4 GB RAM)
+- **Monthly price** (e.g. **US$27/month**)
+- That the charge happens **immediately** upon rental
+
+Then ask a direct yes/no question, for example:
+
+> You are about to rent DigitalOcean New York `s-2vcpu-4gb` for **US$27/month**. This will charge your payment method now. Confirm purchase?
+
+Only proceed after the user clearly and affirmatively confirms **this specific priced option**.
+
+**Never infer purchase consent** from an ambiguous reply — a bare number like "2", an "ok", or a selection the user made before seeing concrete prices does NOT count. A numeric reply is only valid consent if it maps to a numbered option the user already saw with provider, region, spec, and price spelled out. When in doubt, re-confirm instead of renting.
+
 ## Rent a Server
 
 ```bash
@@ -23,7 +43,11 @@ npx zeabur@latest server catalog -i=false
 
 ### 2. Pick provider, region, plan from the JSON output
 
-### 3. Rent
+### 3. Present the exact option (provider, region, spec, monthly price, immediate charge) and get the user's explicit confirmation
+
+See the confirmation requirements above. Do not skip this step even if the user previously asked you to rent a server in general terms.
+
+### 4. Rent (only after confirmation)
 
 ```bash
 npx zeabur@latest server rent --provider hetzner --region fsn1 --plan CAX11 -y -i=false

--- a/skills/zeabur-server-rent/SKILL.md
+++ b/skills/zeabur-server-rent/SKILL.md
@@ -7,6 +7,26 @@ description: Use when renting a new dedicated server. Use when user wants to buy
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
 
+## ⚠️ Renting charges real money — explicit confirmation is REQUIRED
+
+`server rent` immediately charges the user's payment method (or Zeabur balance). The `-y` flag skips the CLI's own confirmation prompt, so **you are the last line of defense**: never run `server rent` until the user has explicitly confirmed the exact priced option.
+
+Before renting, you MUST present all of the following to the user in one message:
+
+- **Provider** (e.g. DigitalOcean)
+- **Region** (e.g. New York / `nyc3`)
+- **Plan/spec** (e.g. `s-2vcpu-4gb` — 2 vCPU / 4 GB RAM)
+- **Monthly price** (e.g. **US$27/month**)
+- That the charge happens **immediately** upon rental
+
+Then ask a direct yes/no question, for example:
+
+> You are about to rent DigitalOcean New York `s-2vcpu-4gb` for **US$27/month**. This will charge your payment method now. Confirm purchase?
+
+Only proceed after the user clearly and affirmatively confirms **this specific priced option**.
+
+**Never infer purchase consent** from an ambiguous reply — a bare number like "2", an "ok", or a selection the user made before seeing concrete prices does NOT count. A numeric reply is only valid consent if it maps to a numbered option the user already saw with provider, region, spec, and price spelled out. When in doubt, re-confirm instead of renting.
+
 ## Rent a Server
 
 ```bash
@@ -23,7 +43,11 @@ npx zeabur@latest server catalog -i=false
 
 ### 2. Pick provider, region, plan from the JSON output
 
-### 3. Rent
+### 3. Present the exact option (provider, region, spec, monthly price, immediate charge) and get the user's explicit confirmation
+
+See the confirmation requirements above. Do not skip this step even if the user previously asked you to rent a server in general terms.
+
+### 4. Rent (only after confirmation)
 
 ```bash
 npx zeabur@latest server rent --provider hetzner --region fsn1 --plan CAX11 -y -i=false


### PR DESCRIPTION
## Summary
- Add a mandatory user-confirmation section to the `zeabur-server-rent` skill: before running `server rent`, the Agent must present provider, region, plan/spec, monthly price, and an immediate-charge notice, then get explicit confirmation for that specific priced option
- Forbid inferring purchase consent from ambiguous replies (a bare number like "2", "ok", or a selection made before prices were shown)
- Insert the confirmation step into the workflow so renting only happens after confirmation

## Context
A first-time Dev Plan user was charged US$27 after the Agent interpreted a bare "2" as consent and rented a DigitalOcean server with `-y` (skipping the CLI prompt). Since `-y` bypasses the CLI confirmation, the skill now makes the Agent the last line of defense.

Linear: [DES-765](https://linear.app/zeabur/issue/DES-765)

## Test plan
- [ ] Review the new confirmation requirements for clarity and completeness
- [ ] Verify the workflow steps still read correctly end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785568095&installation_id=128583772&pr_number=71&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F71&signature=8ab456631d1127cfb2b77afffa2b91bb5fdd9b9d034a18c22880b1e51bcf513a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance for rental actions, including a prominent real-money warning and a requirement for explicit confirmation before proceeding.
  * Updated the workflow so the exact option must be shown and confirmed first, then the rental can continue only after unambiguous approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->