### PR TITLE
feat: zeabur-server-ssh skill 改用 server exec（DES-803）

### DIFF
--- a/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
@@ -35,8 +35,8 @@ Notes:
   Quote a compound command (with `&&` / `|` / redirects) as a **single argument**.
 - stdout/stderr stream live; the remote command's **exit code is propagated**.
   A pipeline reports only its **last** command's status, so `... | tail` hides an
-  upstream failure — prefix `set -o pipefail && ...` inside the quoted command
-  when an earlier failure must surface.
+  upstream failure — wrap it as `bash -lc 'set -o pipefail && ...'` when an
+  earlier failure must surface (`set -o pipefail` needs Bash, not `/bin/sh`).
 - If you don't know the server ID, list servers first:
   ```bash
   npx zeabur@latest server list -i=false

--- a/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
@@ -34,6 +34,9 @@ Notes:
 - Everything after `--` is the remote command, joined like `ssh host <command>`.
   Quote a compound command (with `&&` / `|` / redirects) as a **single argument**.
 - stdout/stderr stream live; the remote command's **exit code is propagated**.
+  A pipeline reports only its **last** command's status, so `... | tail` hides an
+  upstream failure — prefix `set -o pipefail && ...` inside the quoted command
+  when an earlier failure must surface.
 - If you don't know the server ID, list servers first:
   ```bash
   npx zeabur@latest server list -i=false
@@ -43,7 +46,10 @@ Notes:
 ## Common kubectl Commands
 
 Pass any of these as the command to `server exec`. **Always use `sudo kubectl`** —
-the SSH user may not have direct access to the k3s kubeconfig.
+the SSH user may not have direct access to the k3s kubeconfig. Any command with a
+pipe (`|`) or `&&` must be **quoted as a single argument**, or the local shell
+splits it and runs part locally — e.g.
+`server exec --id <id> -- 'sudo kubectl top pods -A --sort-by=memory | head -20'`.
 
 | Task | Command |
 |------|---------|

--- a/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
@@ -33,10 +33,9 @@ Notes:
 
 - Everything after `--` is the remote command, joined like `ssh host <command>`.
   Quote a compound command (with `&&` / `|` / redirects) as a **single argument**.
-- stdout/stderr stream live; the remote command's **exit code is propagated**.
-  A pipeline reports only its **last** command's status, so `... | tail` hides an
-  upstream failure — wrap it as `bash -lc 'set -o pipefail && ...'` when an
-  earlier failure must surface (`set -o pipefail` needs Bash, not `/bin/sh`).
+- stdout/stderr stream live; the remote command's **exit code is propagated**
+  (a pipeline reports only its **last** stage's status — `… | tail` hides an
+  upstream failure, so don't rely on the exit code across a pipe).
 - If you don't know the server ID, list servers first:
   ```bash
   npx zeabur@latest server list -i=false

--- a/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
@@ -1,53 +1,88 @@
 ---
 name: zeabur-server-ssh
-description: Use when debugging services on a user's dedicated server via SSH. Use when needing to inspect pods, check container logs, view k8s resources, or run kubectl commands on the server. Use when "service exec" is insufficient and you need server-level access. Use when user says "check my server", "debug pod", "kubectl", "SSH into server", "check k8s", or "inspect cluster".
+description: Use when debugging services on a user's dedicated server via SSH. Use when needing to run a command on the server, inspect pods, check container logs, view k8s resources, or run kubectl commands. Use when "service exec" is insufficient and you need server-level access. Use when user says "check my server", "run X on my server", "debug pod", "kubectl", "SSH into server", "check k8s", or "inspect cluster".
 ---
 
 # Zeabur Server SSH + kubectl
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method.
 
-SSH into a user's dedicated server and use kubectl to debug Kubernetes workloads. Zeabur dedicated servers run k3s with kubectl pre-installed.
+Run commands on a user's dedicated server and use kubectl to debug Kubernetes workloads. Zeabur dedicated servers run k3s with kubectl pre-installed.
 
-## Step 1: Get SSH Credentials
+## Run a command: `server exec` (recommended)
+
+Run a command on the server in one step. The CLI fetches the credentials and opens
+the connection internally, so **you never handle the password** — passwords with
+special characters just work, and no `ssh2`/`sshpass` is needed.
+
+```bash
+npx zeabur@latest server exec --id <server-id> -- <command>
+```
+
+Examples:
+
+```bash
+# Single command
+npx zeabur@latest server exec --id <server-id> -- sudo kubectl get pods -A -o wide
+
+# Compound command — quote it as ONE argument so && / | stay intact
+npx zeabur@latest server exec --id <server-id> -- 'echo "=== PODS ===" && sudo kubectl get pods -A && echo "=== EVENTS ===" && sudo kubectl get events -A --sort-by=.lastTimestamp | tail -20'
+```
+
+Notes:
+
+- Everything after `--` is the remote command, joined like `ssh host <command>`.
+  Quote a compound command (with `&&` / `|` / redirects) as a **single argument**.
+- stdout/stderr stream live; the remote command's **exit code is propagated**.
+- If you don't know the server ID, list servers first:
+  ```bash
+  npx zeabur@latest server list -i=false
+  ```
+  (or use the `zeabur-server-list` skill).
+
+## Common kubectl Commands
+
+Pass any of these as the command to `server exec`. **Always use `sudo kubectl`** —
+the SSH user may not have direct access to the k3s kubeconfig.
+
+| Task | Command |
+|------|---------|
+| List all pods | `sudo kubectl get pods -A -o wide` |
+| Problem pods only | `sudo kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded` |
+| Pod logs | `sudo kubectl logs <pod-name> -n <namespace> --tail=100` |
+| Exec into container | `sudo kubectl exec <pod-name> -n <namespace> -- <command>` |
+| Node resources | `sudo kubectl top nodes` |
+| Pod resources | `sudo kubectl top pods -A --sort-by=memory \| head -20` |
+| Describe pod | `sudo kubectl describe pod <pod-name> -n <namespace>` |
+| Recent events | `sudo kubectl get events -A --sort-by=.lastTimestamp \| tail -30` |
+| Restart deployment | `sudo kubectl rollout restart deployment/<name> -n <namespace>` |
+
+## Fallback: manual SSH (only if `server exec` is unavailable)
+
+Use this **only** if `server exec` isn't available (e.g. an older CLI). Otherwise
+prefer `server exec` above — this path is fragile with special-character passwords.
+
+### Step 1: Get SSH credentials
 
 ```bash
 npx zeabur@latest server ssh-info --id <server-id> -i=false
 ```
 
-Output is JSON:
-```json
-{"ip":"1.2.3.4","port":22,"username":"root","password":"xxx"}
-```
+Output is JSON: `{"ip":"1.2.3.4","port":22,"username":"root","password":"xxx"}`
 
-If you don't know the server ID, list servers first:
-```bash
-npx zeabur@latest server list -i=false
-```
+### Step 2: Connect
 
-## Step 2: Run Commands via SSH
-
-Use the Node.js `ssh2` method by default. Use `sshpass` only when its availability is already known.
-
-### Option A: sshpass (only if already known to be available)
+Use the Node.js `ssh2` method by default; use `sshpass` only when its availability
+is already known. Do NOT run `which sshpass` to check — it wastes a step where it's
+never installed.
 
 ```bash
-# Single command
+# sshpass (only if already known to be available)
 sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> sudo kubectl get pods -A
-
-# Multiple commands in one SSH call
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
-  echo "=== PODS ===" && sudo kubectl get pods -A &&
-  echo "=== SERVICES ===" && sudo kubectl get svc -A &&
-  echo "=== EVENTS ===" && sudo kubectl get events -A --sort-by=.lastTimestamp | tail -20
-'
 ```
 
-### Option B: Node.js ssh2 (default)
-
-The Zeabur agent sandbox has `ssh2` pre-installed. Use this approach by default:
-
 ```bash
+# Node.js ssh2 (the Zeabur agent sandbox has it pre-installed)
 NODE_PATH=$([ -d /root/.global/node_modules ] && echo /root/.global/node_modules || echo /home/vercel-sandbox/.global/node_modules) node -e "
 const {Client} = require('ssh2');
 const c = new Client();
@@ -68,46 +103,14 @@ c.on('ready', () => {
 "
 ```
 
-For multiple commands, join them with `&&` in the command string:
-
-```bash
-NODE_PATH=$([ -d /root/.global/node_modules ] && echo /root/.global/node_modules || echo /home/vercel-sandbox/.global/node_modules) node -e "
-const {Client} = require('ssh2');
-const c = new Client();
-c.on('ready', () => {
-  c.exec('echo \"=== PODS ===\" && sudo kubectl get pods -A && echo \"=== SERVICES ===\" && sudo kubectl get svc -A && echo \"=== EVENTS ===\" && sudo kubectl get events -A --sort-by=.lastTimestamp | tail -20', (err, stream) => {
-    if (err) { console.error(err); process.exit(1); }
-    let out = '';
-    stream.on('data', d => out += d);
-    stream.stderr.on('data', d => out += d);
-    stream.on('close', () => { console.log(out); c.end(); });
-  });
-}).connect({host:'<ip>', port:<port>, username:'<username>', password:'<password>'});
-"
-```
-
-## Common kubectl Commands
-
-**Always use `sudo kubectl`** — the SSH user may not have direct access to the k3s kubeconfig.
-
-| Task | Command |
-|------|---------|
-| List all pods | `sudo kubectl get pods -A -o wide` |
-| Problem pods only | `sudo kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded` |
-| Pod logs | `sudo kubectl logs <pod-name> -n <namespace> --tail=100` |
-| Exec into container | `sudo kubectl exec <pod-name> -n <namespace> -- <command>` |
-| Node resources | `sudo kubectl top nodes` |
-| Pod resources | `sudo kubectl top pods -A --sort-by=memory \| head -20` |
-| Describe pod | `sudo kubectl describe pod <pod-name> -n <namespace>` |
-| Recent events | `sudo kubectl get events -A --sort-by=.lastTimestamp \| tail -30` |
-| Restart deployment | `sudo kubectl rollout restart deployment/<name> -n <namespace>` |
-
 ## Tips
 
-- **Use Node.js ssh2 by default (Option B)**: Only use `sshpass` (Option A) if you already know it's available. Do NOT run `which sshpass` to check — it wastes a step in environments where it's never installed.
-- **Combine commands**: Batch related checks with `&&` in a single SSH call to reduce round trips.
-- **Do NOT use `bash -c '...'` over SSH**: Pass commands directly in SSH quotes. Using `bash -c` causes quoting conflicts.
-- **Use `-o wide`**: Adds node name and IP to pod listings, useful for debugging scheduling issues.
-- **Namespace matters**: Zeabur services typically run in non-default namespaces. Use `-A` (all namespaces) first to locate the right namespace, then scope subsequent commands with `-n <namespace>`.
-- **Read project docs first**: If a fix attempt fails, exec into the container and check README or config files before blindly checking metrics: `sudo kubectl exec <pod> -n <ns> -- cat /app/README.md`
-- To find server IDs, use the `zeabur-server-list` skill. For simpler container commands that don't need server-level access, use the `zeabur-service-exec` skill instead.
+- **Combine commands**: batch related checks with `&&` in a single `server exec`
+  call to reduce round trips.
+- **Use `-o wide`**: adds node name and IP to pod listings, useful for scheduling issues.
+- **Namespace matters**: Zeabur services usually run in non-default namespaces. Use
+  `-A` (all namespaces) first to locate the right one, then scope with `-n <namespace>`.
+- **Read project docs first**: if a fix attempt fails, exec into the container and
+  check README/config before blindly checking metrics: `sudo kubectl exec <pod> -n <ns> -- cat /app/README.md`
+- To find server IDs, use the `zeabur-server-list` skill. For simpler container
+  commands that don't need server-level access, use the `zeabur-service-exec` skill.

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -35,8 +35,8 @@ Notes:
   Quote a compound command (with `&&` / `|` / redirects) as a **single argument**.
 - stdout/stderr stream live; the remote command's **exit code is propagated**.
   A pipeline reports only its **last** command's status, so `... | tail` hides an
-  upstream failure — prefix `set -o pipefail && ...` inside the quoted command
-  when an earlier failure must surface.
+  upstream failure — wrap it as `bash -lc 'set -o pipefail && ...'` when an
+  earlier failure must surface (`set -o pipefail` needs Bash, not `/bin/sh`).
 - If you don't know the server ID, list servers first:
   ```bash
   npx zeabur@latest server list -i=false

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -34,6 +34,9 @@ Notes:
 - Everything after `--` is the remote command, joined like `ssh host <command>`.
   Quote a compound command (with `&&` / `|` / redirects) as a **single argument**.
 - stdout/stderr stream live; the remote command's **exit code is propagated**.
+  A pipeline reports only its **last** command's status, so `... | tail` hides an
+  upstream failure — prefix `set -o pipefail && ...` inside the quoted command
+  when an earlier failure must surface.
 - If you don't know the server ID, list servers first:
   ```bash
   npx zeabur@latest server list -i=false
@@ -43,7 +46,10 @@ Notes:
 ## Common kubectl Commands
 
 Pass any of these as the command to `server exec`. **Always use `sudo kubectl`** —
-the SSH user may not have direct access to the k3s kubeconfig.
+the SSH user may not have direct access to the k3s kubeconfig. Any command with a
+pipe (`|`) or `&&` must be **quoted as a single argument**, or the local shell
+splits it and runs part locally — e.g.
+`server exec --id <id> -- 'sudo kubectl top pods -A --sort-by=memory | head -20'`.
 
 | Task | Command |
 |------|---------|

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -33,10 +33,9 @@ Notes:
 
 - Everything after `--` is the remote command, joined like `ssh host <command>`.
   Quote a compound command (with `&&` / `|` / redirects) as a **single argument**.
-- stdout/stderr stream live; the remote command's **exit code is propagated**.
-  A pipeline reports only its **last** command's status, so `... | tail` hides an
-  upstream failure — wrap it as `bash -lc 'set -o pipefail && ...'` when an
-  earlier failure must surface (`set -o pipefail` needs Bash, not `/bin/sh`).
+- stdout/stderr stream live; the remote command's **exit code is propagated**
+  (a pipeline reports only its **last** stage's status — `… | tail` hides an
+  upstream failure, so don't rely on the exit code across a pipe).
 - If you don't know the server ID, list servers first:
   ```bash
   npx zeabur@latest server list -i=false

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -1,53 +1,88 @@
 ---
 name: zeabur-server-ssh
-description: Use when debugging services on a user's dedicated server via SSH. Use when needing to inspect pods, check container logs, view k8s resources, or run kubectl commands on the server. Use when "service exec" is insufficient and you need server-level access. Use when user says "check my server", "debug pod", "kubectl", "SSH into server", "check k8s", or "inspect cluster".
+description: Use when debugging services on a user's dedicated server via SSH. Use when needing to run a command on the server, inspect pods, check container logs, view k8s resources, or run kubectl commands. Use when "service exec" is insufficient and you need server-level access. Use when user says "check my server", "run X on my server", "debug pod", "kubectl", "SSH into server", "check k8s", or "inspect cluster".
 ---
 
 # Zeabur Server SSH + kubectl
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method.
 
-SSH into a user's dedicated server and use kubectl to debug Kubernetes workloads. Zeabur dedicated servers run k3s with kubectl pre-installed.
+Run commands on a user's dedicated server and use kubectl to debug Kubernetes workloads. Zeabur dedicated servers run k3s with kubectl pre-installed.
 
-## Step 1: Get SSH Credentials
+## Run a command: `server exec` (recommended)
+
+Run a command on the server in one step. The CLI fetches the credentials and opens
+the connection internally, so **you never handle the password** — passwords with
+special characters just work, and no `ssh2`/`sshpass` is needed.
+
+```bash
+npx zeabur@latest server exec --id <server-id> -- <command>
+```
+
+Examples:
+
+```bash
+# Single command
+npx zeabur@latest server exec --id <server-id> -- sudo kubectl get pods -A -o wide
+
+# Compound command — quote it as ONE argument so && / | stay intact
+npx zeabur@latest server exec --id <server-id> -- 'echo "=== PODS ===" && sudo kubectl get pods -A && echo "=== EVENTS ===" && sudo kubectl get events -A --sort-by=.lastTimestamp | tail -20'
+```
+
+Notes:
+
+- Everything after `--` is the remote command, joined like `ssh host <command>`.
+  Quote a compound command (with `&&` / `|` / redirects) as a **single argument**.
+- stdout/stderr stream live; the remote command's **exit code is propagated**.
+- If you don't know the server ID, list servers first:
+  ```bash
+  npx zeabur@latest server list -i=false
+  ```
+  (or use the `zeabur-server-list` skill).
+
+## Common kubectl Commands
+
+Pass any of these as the command to `server exec`. **Always use `sudo kubectl`** —
+the SSH user may not have direct access to the k3s kubeconfig.
+
+| Task | Command |
+|------|---------|
+| List all pods | `sudo kubectl get pods -A -o wide` |
+| Problem pods only | `sudo kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded` |
+| Pod logs | `sudo kubectl logs <pod-name> -n <namespace> --tail=100` |
+| Exec into container | `sudo kubectl exec <pod-name> -n <namespace> -- <command>` |
+| Node resources | `sudo kubectl top nodes` |
+| Pod resources | `sudo kubectl top pods -A --sort-by=memory \| head -20` |
+| Describe pod | `sudo kubectl describe pod <pod-name> -n <namespace>` |
+| Recent events | `sudo kubectl get events -A --sort-by=.lastTimestamp \| tail -30` |
+| Restart deployment | `sudo kubectl rollout restart deployment/<name> -n <namespace>` |
+
+## Fallback: manual SSH (only if `server exec` is unavailable)
+
+Use this **only** if `server exec` isn't available (e.g. an older CLI). Otherwise
+prefer `server exec` above — this path is fragile with special-character passwords.
+
+### Step 1: Get SSH credentials
 
 ```bash
 npx zeabur@latest server ssh-info --id <server-id> -i=false
 ```
 
-Output is JSON:
-```json
-{"ip":"1.2.3.4","port":22,"username":"root","password":"xxx"}
-```
+Output is JSON: `{"ip":"1.2.3.4","port":22,"username":"root","password":"xxx"}`
 
-If you don't know the server ID, list servers first:
-```bash
-npx zeabur@latest server list -i=false
-```
+### Step 2: Connect
 
-## Step 2: Run Commands via SSH
-
-Use the Node.js `ssh2` method by default. Use `sshpass` only when its availability is already known.
-
-### Option A: sshpass (only if already known to be available)
+Use the Node.js `ssh2` method by default; use `sshpass` only when its availability
+is already known. Do NOT run `which sshpass` to check — it wastes a step where it's
+never installed.
 
 ```bash
-# Single command
+# sshpass (only if already known to be available)
 sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> sudo kubectl get pods -A
-
-# Multiple commands in one SSH call
-sshpass -p '<password>' ssh -o StrictHostKeyChecking=no -p <port> <username>@<ip> '
-  echo "=== PODS ===" && sudo kubectl get pods -A &&
-  echo "=== SERVICES ===" && sudo kubectl get svc -A &&
-  echo "=== EVENTS ===" && sudo kubectl get events -A --sort-by=.lastTimestamp | tail -20
-'
 ```
 
-### Option B: Node.js ssh2 (default)
-
-The Zeabur agent sandbox has `ssh2` pre-installed. Use this approach by default:
-
 ```bash
+# Node.js ssh2 (the Zeabur agent sandbox has it pre-installed)
 NODE_PATH=$([ -d /root/.global/node_modules ] && echo /root/.global/node_modules || echo /home/vercel-sandbox/.global/node_modules) node -e "
 const {Client} = require('ssh2');
 const c = new Client();
@@ -68,46 +103,14 @@ c.on('ready', () => {
 "
 ```
 
-For multiple commands, join them with `&&` in the command string:
-
-```bash
-NODE_PATH=$([ -d /root/.global/node_modules ] && echo /root/.global/node_modules || echo /home/vercel-sandbox/.global/node_modules) node -e "
-const {Client} = require('ssh2');
-const c = new Client();
-c.on('ready', () => {
-  c.exec('echo \"=== PODS ===\" && sudo kubectl get pods -A && echo \"=== SERVICES ===\" && sudo kubectl get svc -A && echo \"=== EVENTS ===\" && sudo kubectl get events -A --sort-by=.lastTimestamp | tail -20', (err, stream) => {
-    if (err) { console.error(err); process.exit(1); }
-    let out = '';
-    stream.on('data', d => out += d);
-    stream.stderr.on('data', d => out += d);
-    stream.on('close', () => { console.log(out); c.end(); });
-  });
-}).connect({host:'<ip>', port:<port>, username:'<username>', password:'<password>'});
-"
-```
-
-## Common kubectl Commands
-
-**Always use `sudo kubectl`** — the SSH user may not have direct access to the k3s kubeconfig.
-
-| Task | Command |
-|------|---------|
-| List all pods | `sudo kubectl get pods -A -o wide` |
-| Problem pods only | `sudo kubectl get pods -A --field-selector=status.phase!=Running,status.phase!=Succeeded` |
-| Pod logs | `sudo kubectl logs <pod-name> -n <namespace> --tail=100` |
-| Exec into container | `sudo kubectl exec <pod-name> -n <namespace> -- <command>` |
-| Node resources | `sudo kubectl top nodes` |
-| Pod resources | `sudo kubectl top pods -A --sort-by=memory \| head -20` |
-| Describe pod | `sudo kubectl describe pod <pod-name> -n <namespace>` |
-| Recent events | `sudo kubectl get events -A --sort-by=.lastTimestamp \| tail -30` |
-| Restart deployment | `sudo kubectl rollout restart deployment/<name> -n <namespace>` |
-
 ## Tips
 
-- **Use Node.js ssh2 by default (Option B)**: Only use `sshpass` (Option A) if you already know it's available. Do NOT run `which sshpass` to check — it wastes a step in environments where it's never installed.
-- **Combine commands**: Batch related checks with `&&` in a single SSH call to reduce round trips.
-- **Do NOT use `bash -c '...'` over SSH**: Pass commands directly in SSH quotes. Using `bash -c` causes quoting conflicts.
-- **Use `-o wide`**: Adds node name and IP to pod listings, useful for debugging scheduling issues.
-- **Namespace matters**: Zeabur services typically run in non-default namespaces. Use `-A` (all namespaces) first to locate the right namespace, then scope subsequent commands with `-n <namespace>`.
-- **Read project docs first**: If a fix attempt fails, exec into the container and check README or config files before blindly checking metrics: `sudo kubectl exec <pod> -n <ns> -- cat /app/README.md`
-- To find server IDs, use the `zeabur-server-list` skill. For simpler container commands that don't need server-level access, use the `zeabur-service-exec` skill instead.
+- **Combine commands**: batch related checks with `&&` in a single `server exec`
+  call to reduce round trips.
+- **Use `-o wide`**: adds node name and IP to pod listings, useful for scheduling issues.
+- **Namespace matters**: Zeabur services usually run in non-default namespaces. Use
+  `-A` (all namespaces) first to locate the right one, then scope with `-n <namespace>`.
+- **Read project docs first**: if a fix attempt fails, exec into the container and
+  check README/config before blindly checking metrics: `sudo kubectl exec <pod> -n <ns> -- cat /app/README.md`
+- To find server IDs, use the `zeabur-server-list` skill. For simpler container
+  commands that don't need server-level access, use the `zeabur-service-exec` skill.


### PR DESCRIPTION
> ⚠️ **DRAFT — 先別 merge。** 這個 skill 改動相依於 CLI `server exec` 發版到 npm。
> **前置**：zeabur/cli#263（DES-802）merge + CLI 發新版。發版後才 mark ready / merge。

## 背景
`zeabur-server-ssh` skill 原本教兩步：`server ssh-info` 拿憑證 → 自己拼 ssh2/sshpass。這對含特殊字元的密碼會轉義崩壞（密碼被塞進多層轉義 shell 腳本），也綁死 sandbox 專屬 `NODE_PATH`。

## 改動
把 **`zeabur server exec --id <id> -- <command>`** 設為主要方法：CLI 內部拿憑證、跑命令，密碼不經 shell、不需 ssh2/sshpass。
- kubectl 範例改用 `server exec`。
- 保留 `ssh-info` + ssh2/sshpass 為 fallback（舊 CLI 用）。
- 更新 frontmatter description 觸發詞（加「run a command on server」）。
- 已跑 `scripts/sync-codex-plugin.mjs` 重新產生 `plugins/zeabur/`（CI sync 檢查會過）。

## 為什麼保留 fallback
`npx zeabur@latest` 一定抓最新版，發版後 `server exec` 就有了。fallback 是保險：萬一極舊快取 / 未發版環境，agent 仍能用兩步式。

## 影響範圍
skill 是 marketplace plugin，用戶自己的 coding agent 也會用 —— `server exec` 對他們是增益（更簡單、不用 ssh2）、不破壞既有兩步式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786264794&installation_id=128583772&pr_number=72&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F72&signature=bfe5553d24eedc8d07c73b9edc0d5a0af98dd4a39904789c733f053bbbe15fe7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the dedicated-server SSH/exec skill guide to make `npx zeabur@latest server exec` the primary workflow for running server-level commands and debugging Kubernetes workloads.
  - Clarified that credential/password handling is managed by the CLI, and improved guidance on quoting compound remote commands and correctly propagating exit codes.
  - Reorganized and expanded `kubectl` instructions around `server exec`, including an “always use `sudo kubectl`” requirement and a compact command reference.
  - Streamlined the manual SSH fallback and refreshed troubleshooting tips (batching checks, `-o wide`, namespace discovery/scoping, and server vs service pointers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->