### PR TITLE
feat(skills): add zeabur-cluster-scale for LKE/EKS node pool scaling

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zeabur",
   "description": "Zeabur CLI skills for deployment, template management, and troubleshooting",
-  "version": "1.19.0",
+  "version": "1.20.0",
   "author": {
     "name": "Can"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.18.0",
+  "version": "1.20.0",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Zeabur Agent Skills — a plugin providing CLI-based skills for managing Zeabur 
 |----------|--------|
 | Deployment & Logs | `zeabur-deploy`, `zeabur-dockerfile`, `zeabur-deployment-logs`, `zeabur-template-deploy`, `zeabur-template-backup` |
 | Service Management | `zeabur-service-list`, `zeabur-service-delete`, `zeabur-service-exec`, `zeabur-service-metric`, `zeabur-restart`, `zeabur-update-service`, `zeabur-variables` |
-| Server Management | `zeabur-server-list`, `zeabur-server-catalog`, `zeabur-server-rent` |
+| Server Management | `zeabur-server-list`, `zeabur-server-catalog`, `zeabur-server-rent`, `zeabur-cluster-scale` |
 | Project Management | `zeabur-project-create`, `zeabur-project-delete` |
 | Domain & Email | `zeabur-domain-register`, `zeabur-domain-dns`, `zeabur-domain-url`, `zeabur-email` |
 | AI Hub | `zeabur-ai-hub` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Zeabur Claude Plugin — a Claude Code plugin providing CLI-based skills for man
 | Deployment & Logs | `zeabur-deploy`, `zeabur-dockerfile`, `zeabur-deployment-logs`, `zeabur-template-deploy`, `zeabur-template-backup` |
 | Service Management | `zeabur-service-list`, `zeabur-restart`, `zeabur-update-service`, `zeabur-variables` |
 | Database & Storage | `zeabur-database`, `zeabur-object-storage` |
-| Server Management | `zeabur-server-list`, `zeabur-server-catalog`, `zeabur-server-rent` |
+| Server Management | `zeabur-server-list`, `zeabur-server-catalog`, `zeabur-server-rent`, `zeabur-cluster-scale` |
 | Project Management | `zeabur-project-create` |
 | Domain Registration | `zeabur-domain-register`, `zeabur-domain-dns` |
 | Troubleshooting | `zeabur-domain-url`, `zeabur-migration`, `zeabur-port-mismatch`, `zeabur-startup-order` |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ codex --plugin-dir /path/to/agent-skills
 | `zeabur-server-list` | List, get, reboot, and SSH into dedicated servers | Checking server status, IP, rebooting, or SSH access |
 | `zeabur-server-catalog` | Browse available server providers/regions/plans | User asks what servers are available to rent |
 | `zeabur-server-rent` | Rent a new dedicated server | User wants to buy or provision a server |
+| `zeabur-cluster-scale` | Scale dedicated Kubernetes clusters (LKE/EKS) via node pools | User wants to add/remove nodes or resize a cluster |
 | `zeabur-service-list` | List all services and get service IDs | Needing service IDs or checking existing services |
 | `zeabur-startup-order` | Fix connection errors from startup order | Service fails with connection refused to database/redis |
 | `zeabur-template` | Template knowledge base for creating, validating, and troubleshooting | Creating or editing Zeabur template YAML, converting docker-compose |
@@ -63,6 +64,10 @@ codex --plugin-dir /path/to/agent-skills
 | `zeabur-domain-registrant` | Manage registrant profiles for domain registration | Creating/updating contact info for domains |
 
 ## Changelog
+
+### 1.20.0
+
+- Added `zeabur-cluster-scale` — list, scale, add, and remove node pools on dedicated Kubernetes clusters (LKE/EKS) via the GraphQL API, with explicit priced confirmation before every change
 
 ### 1.16.0
 

--- a/plugins/zeabur/.codex-plugin/plugin.json
+++ b/plugins/zeabur/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.18.0",
+  "version": "1.20.0",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/plugins/zeabur/skills/zeabur-cluster-scale/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-cluster-scale/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: zeabur-cluster-scale
+description: Use when scaling a dedicated Kubernetes cluster (Linode LKE or AWS EKS) on Zeabur — listing node pools, changing node counts, or adding/removing node pools. Use when user says "scale my cluster", "add nodes", "remove nodes", "resize node pool", "加節點", "擴容", "縮容". Do NOT use for renting new servers (use zeabur-server-rent) or for single-VM dedicated servers (they have no node pools).
+---
+
+# Zeabur Cluster Scaling (LKE / EKS Node Pools)
+
+> Node pool operations are **not in the Zeabur CLI yet** — call the Zeabur GraphQL API directly at `https://api.zeabur.com/graphql`. The API maps 1:1 onto provider primitives: a node pool is an EKS managed node group or a Linode LKE node pool.
+
+## ⚠️ Scaling changes real billing — explicit confirmation is REQUIRED
+
+Adding nodes or node pools increases the cluster's monthly subscription price; the price is recalculated automatically from the underlying provider resources after every change. **You are the last line of defense**: never run a mutation until the user has explicitly confirmed the exact change.
+
+Before any mutation, present all of the following in one message:
+
+- **Cluster** (name + server ID)
+- **Node pool** (instance type + current node count)
+- **The exact change** (e.g. `3 → 5 nodes`, or "add pool `g6-standard-4` × 2")
+- **Current monthly price** (from `Server.price`) and that it **will increase/decrease automatically** after the change
+
+Then ask a direct yes/no question, for example:
+
+> You are about to scale node pool `g6-standard-4` on cluster `my-cluster` from **3 to 5 nodes**. Your current price is **US$180/month** and will increase roughly proportionally. Confirm?
+
+**Never infer consent** from an ambiguous reply. A bare "ok" before seeing concrete numbers does NOT count. When in doubt, re-confirm instead of mutating.
+
+## Authentication
+
+All requests need a Bearer token:
+
+```bash
+TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml | awk '{print $2}')}"
+```
+
+- Prefer the `ZEABUR_API_KEY` environment variable if set
+- Otherwise reuse the CLI token from `~/.config/zeabur/cli.yaml` (present after `npx zeabur@latest auth login` — use the `zeabur-auth` skill if the user is not logged in)
+
+All node pool mutations require **manage access** to the cluster (owner or admin). Collaborators with view-only access can list pools but not change them.
+
+## 1. Find the cluster's server ID
+
+```bash
+npx zeabur@latest server list -i=false
+```
+
+Only dedicated Kubernetes clusters (LKE / EKS) have node pools. If unsure whether a server is a cluster, check `clusterType` in the query below — clusters return `"dedicated_cluster"` and a non-empty `nodePools`.
+
+## 2. List node pools
+
+```bash
+curl -s https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"query":"query($id: ObjectID!) { server(_id: $id) { name clusterType price nodePools { id instanceType nodeCount minNodes maxNodes readyNodes status } } }","variables":{"id":"<server-id>"}}'
+```
+
+Field notes:
+
+- `id` — the provider-side identifier (EKS node group name, or LKE node pool ID). Pass it as `nodePoolID` in the mutations below.
+- `instanceType` — provider machine type backing the pool (e.g. `t3.2xlarge` for EKS, `g6-standard-4` for LKE)
+- `nodeCount` vs `readyNodes` — desired vs currently-in-service. They differ while a scale operation is in progress.
+- `minNodes` / `maxNodes` — autoscaling floor/ceiling; both `0` when autoscaling is not configured
+- `price` — the cluster's current monthly subscription price; quote it in the confirmation message
+
+## 3. Scale an existing node pool
+
+The most common operation — changes the node count of a pool in place:
+
+```bash
+curl -s https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"query":"mutation($sid: ObjectID!, $pid: String!, $n: Int!) { scaleNodePool(serverID: $sid, nodePoolID: $pid, nodeCount: $n) }","variables":{"sid":"<server-id>","pid":"<node-pool-id>","n":5}}'
+```
+
+After mutating, poll the list query until `readyNodes` equals the new `nodeCount` (provider provisioning typically takes a few minutes), then report the updated pool and price to the user.
+
+**Scaling down:** warn the user that removed nodes are drained and their workloads reschedule onto the remaining nodes — make sure remaining capacity fits the current workload (check with the `zeabur-service-metric` skill if needed). Never scale the cluster's only pool to 0.
+
+## 4. Add a node pool
+
+Use when the user needs a different machine type (e.g. adding bigger or GPU nodes) rather than more of the same:
+
+```bash
+curl -s https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"query":"mutation($sid: ObjectID!, $t: String!, $n: Int!) { addNodePool(serverID: $sid, instanceType: $t, nodeCount: $n) { id instanceType nodeCount status } }","variables":{"sid":"<server-id>","t":"g6-standard-4","n":2}}'
+```
+
+`instanceType` is passed through to the provider verbatim — you are expected to look up a valid type first:
+
+- **LKE (Linode)**: `curl -s https://api.linode.com/v4/linode/types` — public, no auth. Use the type `id` (e.g. `g6-standard-4`, `g6-dedicated-8`).
+- **EKS (AWS)**: any EC2 instance type available in the cluster's region (e.g. `t3.2xlarge`, `m6i.xlarge`). When unsure, ask the user or match the instance type of an existing pool.
+
+An invalid or out-of-region instance type fails at the provider — the error message is passed through in the GraphQL `errors` array.
+
+## 5. Remove a node pool
+
+**Destructive.** All nodes in the pool are drained and deleted; workloads reschedule onto the remaining pools. Never remove the last node pool of a cluster. Requires the same explicit confirmation as above, plus naming the pool being removed.
+
+```bash
+curl -s https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"query":"mutation($sid: ObjectID!, $pid: String!) { removeNodePool(serverID: $sid, nodePoolID: $pid) }","variables":{"sid":"<server-id>","pid":"<node-pool-id>"}}'
+```
+
+## Recommended guidance flow
+
+When the user asks to scale (or complains about capacity):
+
+1. **Show current state first** — list node pools with ready counts and the current monthly price
+2. **Propose a concrete change** — which pool, what count (or what new instance type), and the billing impact
+3. **Get explicit confirmation** — see the confirmation requirements at the top
+4. **Mutate, then watch** — poll until `readyNodes` catches up; report completion and the updated price
+
+## Errors
+
+- `401` / unauthenticated — token missing or expired: re-run `npx zeabur@latest auth login` or check `ZEABUR_API_KEY`
+- "requires manage access" — the user is not the cluster's owner/admin; they must ask the owner to perform the change
+- Empty `nodePools` — the server is not a dedicated Kubernetes cluster (single-VM dedicated servers cannot be scaled this way; suggest `zeabur-server-rent` for renting more capacity)
+- Provider-side errors (invalid instance type, capacity unavailable in region) are surfaced verbatim in the GraphQL `errors` array — relay them to the user and suggest an alternative type/region

--- a/plugins/zeabur/skills/zeabur-cluster-scale/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-cluster-scale/SKILL.md
@@ -26,14 +26,19 @@ Then ask a direct yes/no question, for example:
 
 ## Authentication
 
-All requests need a Bearer token:
+All requests need a Bearer token. Keep the token out of the process list — write it into a `0600` curl config and pass that with `-K`, instead of putting `-H "Authorization: ..."` on the command line:
 
 ```bash
 TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml | awk '{print $2}')}"
+ZAPI_CFG=$(mktemp)
+chmod 600 "$ZAPI_CFG"
+printf 'header = "Authorization: Bearer %s"\n' "$TOKEN" > "$ZAPI_CFG"
+unset TOKEN
 ```
 
 - Prefer the `ZEABUR_API_KEY` environment variable if set
 - Otherwise reuse the CLI token from `~/.config/zeabur/cli.yaml` (present after `npx zeabur@latest auth login` — use the `zeabur-auth` skill if the user is not logged in)
+- Each tool/Bash invocation is a fresh shell — run this setup in the same shell block as the requests that use `$ZAPI_CFG`, and `rm -f "$ZAPI_CFG"` when done
 
 All node pool mutations require **manage access** to the cluster (owner or admin). Collaborators with view-only access can list pools but not change them.
 
@@ -48,9 +53,8 @@ Only dedicated Kubernetes clusters (LKE / EKS) have node pools. If unsure whethe
 ## 2. List node pools
 
 ```bash
-curl -s https://api.zeabur.com/graphql \
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
   -d '{"query":"query($id: ObjectID!) { server(_id: $id) { name clusterType price nodePools { id instanceType nodeCount minNodes maxNodes readyNodes status } } }","variables":{"id":"<server-id>"}}'
 ```
 
@@ -67,13 +71,14 @@ Field notes:
 The most common operation — changes the node count of a pool in place:
 
 ```bash
-curl -s https://api.zeabur.com/graphql \
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
   -d '{"query":"mutation($sid: ObjectID!, $pid: String!, $n: Int!) { scaleNodePool(serverID: $sid, nodePoolID: $pid, nodeCount: $n) }","variables":{"sid":"<server-id>","pid":"<node-pool-id>","n":5}}'
 ```
 
-After mutating, poll the list query until `readyNodes` equals the new `nodeCount` (provider provisioning typically takes a few minutes), then report the updated pool and price to the user.
+After mutating, poll the list query every ~30 seconds until `readyNodes` equals the new `nodeCount` **and** the pool `status` is healthy (`ACTIVE` for EKS, `ready` for LKE) — provisioning typically takes a few minutes. **Bound the wait**: if the pool reports a failed/degraded `status`, stop immediately and relay it; if it has not converged after ~15 minutes, stop polling and report the current state instead of waiting forever. On success, report the updated pool and price to the user.
+
+**If a mutation request times out or fails at the transport layer, never blind-retry.** The change may have been applied server-side — re-fetch the node pool list first, and only retry if the state shows the change did not happen. Blind-retrying `addNodePool` can double-provision (and double-bill); blind-retrying `removeNodePool` can hit a second pool if IDs were reused from a stale list.
 
 **Scaling down:** warn the user that removed nodes are drained and their workloads reschedule onto the remaining nodes — make sure remaining capacity fits the current workload (check with the `zeabur-service-metric` skill if needed). Never scale the cluster's only pool to 0.
 
@@ -82,9 +87,8 @@ After mutating, poll the list query until `readyNodes` equals the new `nodeCount
 Use when the user needs a different machine type (e.g. adding bigger or GPU nodes) rather than more of the same:
 
 ```bash
-curl -s https://api.zeabur.com/graphql \
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
   -d '{"query":"mutation($sid: ObjectID!, $t: String!, $n: Int!) { addNodePool(serverID: $sid, instanceType: $t, nodeCount: $n) { id instanceType nodeCount status } }","variables":{"sid":"<server-id>","t":"g6-standard-4","n":2}}'
 ```
 
@@ -100,11 +104,12 @@ An invalid or out-of-region instance type fails at the provider — the error me
 **Destructive.** All nodes in the pool are drained and deleted; workloads reschedule onto the remaining pools. Never remove the last node pool of a cluster. Requires the same explicit confirmation as above, plus naming the pool being removed.
 
 ```bash
-curl -s https://api.zeabur.com/graphql \
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
   -d '{"query":"mutation($sid: ObjectID!, $pid: String!) { removeNodePool(serverID: $sid, nodePoolID: $pid) }","variables":{"sid":"<server-id>","pid":"<node-pool-id>"}}'
 ```
+
+Completion check for removal: poll the list query (same bounds as above) until the pool **no longer appears** in `nodePools`, then report the updated price.
 
 ## Recommended guidance flow
 
@@ -113,7 +118,7 @@ When the user asks to scale (or complains about capacity):
 1. **Show current state first** — list node pools with ready counts and the current monthly price
 2. **Propose a concrete change** — which pool, what count (or what new instance type), and the billing impact
 3. **Get explicit confirmation** — see the confirmation requirements at the top
-4. **Mutate, then watch** — poll until `readyNodes` catches up; report completion and the updated price
+4. **Mutate, then watch** — poll with the bounds above until the operation-specific completion check passes (scale/add: `readyNodes` matches and `status` healthy; remove: pool gone from the list); report completion and the updated price
 
 ## Errors
 

--- a/skills/zeabur-cluster-scale/SKILL.md
+++ b/skills/zeabur-cluster-scale/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: zeabur-cluster-scale
+description: Use when scaling a dedicated Kubernetes cluster (Linode LKE or AWS EKS) on Zeabur — listing node pools, changing node counts, or adding/removing node pools. Use when user says "scale my cluster", "add nodes", "remove nodes", "resize node pool", "加節點", "擴容", "縮容". Do NOT use for renting new servers (use zeabur-server-rent) or for single-VM dedicated servers (they have no node pools).
+---
+
+# Zeabur Cluster Scaling (LKE / EKS Node Pools)
+
+> Node pool operations are **not in the Zeabur CLI yet** — call the Zeabur GraphQL API directly at `https://api.zeabur.com/graphql`. The API maps 1:1 onto provider primitives: a node pool is an EKS managed node group or a Linode LKE node pool.
+
+## ⚠️ Scaling changes real billing — explicit confirmation is REQUIRED
+
+Adding nodes or node pools increases the cluster's monthly subscription price; the price is recalculated automatically from the underlying provider resources after every change. **You are the last line of defense**: never run a mutation until the user has explicitly confirmed the exact change.
+
+Before any mutation, present all of the following in one message:
+
+- **Cluster** (name + server ID)
+- **Node pool** (instance type + current node count)
+- **The exact change** (e.g. `3 → 5 nodes`, or "add pool `g6-standard-4` × 2")
+- **Current monthly price** (from `Server.price`) and that it **will increase/decrease automatically** after the change
+
+Then ask a direct yes/no question, for example:
+
+> You are about to scale node pool `g6-standard-4` on cluster `my-cluster` from **3 to 5 nodes**. Your current price is **US$180/month** and will increase roughly proportionally. Confirm?
+
+**Never infer consent** from an ambiguous reply. A bare "ok" before seeing concrete numbers does NOT count. When in doubt, re-confirm instead of mutating.
+
+## Authentication
+
+All requests need a Bearer token:
+
+```bash
+TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml | awk '{print $2}')}"
+```
+
+- Prefer the `ZEABUR_API_KEY` environment variable if set
+- Otherwise reuse the CLI token from `~/.config/zeabur/cli.yaml` (present after `npx zeabur@latest auth login` — use the `zeabur-auth` skill if the user is not logged in)
+
+All node pool mutations require **manage access** to the cluster (owner or admin). Collaborators with view-only access can list pools but not change them.
+
+## 1. Find the cluster's server ID
+
+```bash
+npx zeabur@latest server list -i=false
+```
+
+Only dedicated Kubernetes clusters (LKE / EKS) have node pools. If unsure whether a server is a cluster, check `clusterType` in the query below — clusters return `"dedicated_cluster"` and a non-empty `nodePools`.
+
+## 2. List node pools
+
+```bash
+curl -s https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"query":"query($id: ObjectID!) { server(_id: $id) { name clusterType price nodePools { id instanceType nodeCount minNodes maxNodes readyNodes status } } }","variables":{"id":"<server-id>"}}'
+```
+
+Field notes:
+
+- `id` — the provider-side identifier (EKS node group name, or LKE node pool ID). Pass it as `nodePoolID` in the mutations below.
+- `instanceType` — provider machine type backing the pool (e.g. `t3.2xlarge` for EKS, `g6-standard-4` for LKE)
+- `nodeCount` vs `readyNodes` — desired vs currently-in-service. They differ while a scale operation is in progress.
+- `minNodes` / `maxNodes` — autoscaling floor/ceiling; both `0` when autoscaling is not configured
+- `price` — the cluster's current monthly subscription price; quote it in the confirmation message
+
+## 3. Scale an existing node pool
+
+The most common operation — changes the node count of a pool in place:
+
+```bash
+curl -s https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"query":"mutation($sid: ObjectID!, $pid: String!, $n: Int!) { scaleNodePool(serverID: $sid, nodePoolID: $pid, nodeCount: $n) }","variables":{"sid":"<server-id>","pid":"<node-pool-id>","n":5}}'
+```
+
+After mutating, poll the list query until `readyNodes` equals the new `nodeCount` (provider provisioning typically takes a few minutes), then report the updated pool and price to the user.
+
+**Scaling down:** warn the user that removed nodes are drained and their workloads reschedule onto the remaining nodes — make sure remaining capacity fits the current workload (check with the `zeabur-service-metric` skill if needed). Never scale the cluster's only pool to 0.
+
+## 4. Add a node pool
+
+Use when the user needs a different machine type (e.g. adding bigger or GPU nodes) rather than more of the same:
+
+```bash
+curl -s https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"query":"mutation($sid: ObjectID!, $t: String!, $n: Int!) { addNodePool(serverID: $sid, instanceType: $t, nodeCount: $n) { id instanceType nodeCount status } }","variables":{"sid":"<server-id>","t":"g6-standard-4","n":2}}'
+```
+
+`instanceType` is passed through to the provider verbatim — you are expected to look up a valid type first:
+
+- **LKE (Linode)**: `curl -s https://api.linode.com/v4/linode/types` — public, no auth. Use the type `id` (e.g. `g6-standard-4`, `g6-dedicated-8`).
+- **EKS (AWS)**: any EC2 instance type available in the cluster's region (e.g. `t3.2xlarge`, `m6i.xlarge`). When unsure, ask the user or match the instance type of an existing pool.
+
+An invalid or out-of-region instance type fails at the provider — the error message is passed through in the GraphQL `errors` array.
+
+## 5. Remove a node pool
+
+**Destructive.** All nodes in the pool are drained and deleted; workloads reschedule onto the remaining pools. Never remove the last node pool of a cluster. Requires the same explicit confirmation as above, plus naming the pool being removed.
+
+```bash
+curl -s https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $TOKEN" \
+  -d '{"query":"mutation($sid: ObjectID!, $pid: String!) { removeNodePool(serverID: $sid, nodePoolID: $pid) }","variables":{"sid":"<server-id>","pid":"<node-pool-id>"}}'
+```
+
+## Recommended guidance flow
+
+When the user asks to scale (or complains about capacity):
+
+1. **Show current state first** — list node pools with ready counts and the current monthly price
+2. **Propose a concrete change** — which pool, what count (or what new instance type), and the billing impact
+3. **Get explicit confirmation** — see the confirmation requirements at the top
+4. **Mutate, then watch** — poll until `readyNodes` catches up; report completion and the updated price
+
+## Errors
+
+- `401` / unauthenticated — token missing or expired: re-run `npx zeabur@latest auth login` or check `ZEABUR_API_KEY`
+- "requires manage access" — the user is not the cluster's owner/admin; they must ask the owner to perform the change
+- Empty `nodePools` — the server is not a dedicated Kubernetes cluster (single-VM dedicated servers cannot be scaled this way; suggest `zeabur-server-rent` for renting more capacity)
+- Provider-side errors (invalid instance type, capacity unavailable in region) are surfaced verbatim in the GraphQL `errors` array — relay them to the user and suggest an alternative type/region

--- a/skills/zeabur-cluster-scale/SKILL.md
+++ b/skills/zeabur-cluster-scale/SKILL.md
@@ -26,14 +26,19 @@ Then ask a direct yes/no question, for example:
 
 ## Authentication
 
-All requests need a Bearer token:
+All requests need a Bearer token. Keep the token out of the process list — write it into a `0600` curl config and pass that with `-K`, instead of putting `-H "Authorization: ..."` on the command line:
 
 ```bash
 TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml | awk '{print $2}')}"
+ZAPI_CFG=$(mktemp)
+chmod 600 "$ZAPI_CFG"
+printf 'header = "Authorization: Bearer %s"\n' "$TOKEN" > "$ZAPI_CFG"
+unset TOKEN
 ```
 
 - Prefer the `ZEABUR_API_KEY` environment variable if set
 - Otherwise reuse the CLI token from `~/.config/zeabur/cli.yaml` (present after `npx zeabur@latest auth login` — use the `zeabur-auth` skill if the user is not logged in)
+- Each tool/Bash invocation is a fresh shell — run this setup in the same shell block as the requests that use `$ZAPI_CFG`, and `rm -f "$ZAPI_CFG"` when done
 
 All node pool mutations require **manage access** to the cluster (owner or admin). Collaborators with view-only access can list pools but not change them.
 
@@ -48,9 +53,8 @@ Only dedicated Kubernetes clusters (LKE / EKS) have node pools. If unsure whethe
 ## 2. List node pools
 
 ```bash
-curl -s https://api.zeabur.com/graphql \
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
   -d '{"query":"query($id: ObjectID!) { server(_id: $id) { name clusterType price nodePools { id instanceType nodeCount minNodes maxNodes readyNodes status } } }","variables":{"id":"<server-id>"}}'
 ```
 
@@ -67,13 +71,14 @@ Field notes:
 The most common operation — changes the node count of a pool in place:
 
 ```bash
-curl -s https://api.zeabur.com/graphql \
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
   -d '{"query":"mutation($sid: ObjectID!, $pid: String!, $n: Int!) { scaleNodePool(serverID: $sid, nodePoolID: $pid, nodeCount: $n) }","variables":{"sid":"<server-id>","pid":"<node-pool-id>","n":5}}'
 ```
 
-After mutating, poll the list query until `readyNodes` equals the new `nodeCount` (provider provisioning typically takes a few minutes), then report the updated pool and price to the user.
+After mutating, poll the list query every ~30 seconds until `readyNodes` equals the new `nodeCount` **and** the pool `status` is healthy (`ACTIVE` for EKS, `ready` for LKE) — provisioning typically takes a few minutes. **Bound the wait**: if the pool reports a failed/degraded `status`, stop immediately and relay it; if it has not converged after ~15 minutes, stop polling and report the current state instead of waiting forever. On success, report the updated pool and price to the user.
+
+**If a mutation request times out or fails at the transport layer, never blind-retry.** The change may have been applied server-side — re-fetch the node pool list first, and only retry if the state shows the change did not happen. Blind-retrying `addNodePool` can double-provision (and double-bill); blind-retrying `removeNodePool` can hit a second pool if IDs were reused from a stale list.
 
 **Scaling down:** warn the user that removed nodes are drained and their workloads reschedule onto the remaining nodes — make sure remaining capacity fits the current workload (check with the `zeabur-service-metric` skill if needed). Never scale the cluster's only pool to 0.
 
@@ -82,9 +87,8 @@ After mutating, poll the list query until `readyNodes` equals the new `nodeCount
 Use when the user needs a different machine type (e.g. adding bigger or GPU nodes) rather than more of the same:
 
 ```bash
-curl -s https://api.zeabur.com/graphql \
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
   -d '{"query":"mutation($sid: ObjectID!, $t: String!, $n: Int!) { addNodePool(serverID: $sid, instanceType: $t, nodeCount: $n) { id instanceType nodeCount status } }","variables":{"sid":"<server-id>","t":"g6-standard-4","n":2}}'
 ```
 
@@ -100,11 +104,12 @@ An invalid or out-of-region instance type fails at the provider — the error me
 **Destructive.** All nodes in the pool are drained and deleted; workloads reschedule onto the remaining pools. Never remove the last node pool of a cluster. Requires the same explicit confirmation as above, plus naming the pool being removed.
 
 ```bash
-curl -s https://api.zeabur.com/graphql \
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $TOKEN" \
   -d '{"query":"mutation($sid: ObjectID!, $pid: String!) { removeNodePool(serverID: $sid, nodePoolID: $pid) }","variables":{"sid":"<server-id>","pid":"<node-pool-id>"}}'
 ```
+
+Completion check for removal: poll the list query (same bounds as above) until the pool **no longer appears** in `nodePools`, then report the updated price.
 
 ## Recommended guidance flow
 
@@ -113,7 +118,7 @@ When the user asks to scale (or complains about capacity):
 1. **Show current state first** — list node pools with ready counts and the current monthly price
 2. **Propose a concrete change** — which pool, what count (or what new instance type), and the billing impact
 3. **Get explicit confirmation** — see the confirmation requirements at the top
-4. **Mutate, then watch** — poll until `readyNodes` catches up; report completion and the updated price
+4. **Mutate, then watch** — poll with the bounds above until the operation-specific completion check passes (scale/add: `readyNodes` matches and `status` healthy; remove: pool gone from the list); report completion and the updated price
 
 ## Errors
 


### PR DESCRIPTION
## Summary

- Add `zeabur-cluster-scale` skill: guides agents through scaling dedicated Kubernetes clusters (Linode LKE / AWS EKS) via the GraphQL node pool API from PLA-1877 — list node pools, scale in place, add a pool of a new instance type, remove a pool
- Node pool ops are not in the CLI yet, so the skill calls `https://api.zeabur.com/graphql` directly with the CLI token (`~/.config/zeabur/cli.yaml`) or `ZEABUR_API_KEY`, following the `zeabur-email` curl precedent
- Requires explicit priced confirmation before every mutation (same convention as `zeabur-server-rent`): show cluster, pool, exact change, and current monthly price, then get a direct yes/no
- Bump plugin version to 1.20.0, update README changelog + skill tables, re-run codex plugin sync

## Test plan

- [x] Verified the list query shape against the production API (read-only): `server(_id:)` / `servers` with `nodePools { id instanceType nodeCount minNodes maxNodes readyNodes status }` all resolve; non-cluster servers return empty `nodePools`
- [x] Mutation signatures cross-checked against `schema.graphql` (`addNodePool` / `scaleNodePool` / `removeNodePool`)
- [x] `node scripts/sync-codex-plugin.mjs` run — `plugins/zeabur/` mirror matches root `skills/`

Linear: [PLA-1890](https://linear.app/zeabur/issue/PLA-1890/zeabur-agent-可以引導使用者給-lks-或-eks-擴縮容)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786510904&installation_id=128583772&pr_number=73&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F73&signature=fbef7fc7ce830d48e10097efb5a53d07f3dc244427cbd000ceb2b8d8629c92da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the `zeabur-cluster-scale` skill to help scale dedicated Kubernetes clusters by managing node pools.
  * Added end-to-end guidance for listing node pools and performing safe scale/add/remove operations, including price impact and confirmation for changes that affect billing.

* **Documentation**
  * Updated skill catalogs and changelog materials to include the new `zeabur-cluster-scale` capability.
  * Bumped plugin metadata versions to **1.20.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->