### PR TITLE
fix(skills): align server skills with ZeaburOS and standard VPS

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zeabur",
   "description": "Zeabur CLI skills for deployment, template management, and troubleshooting",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "author": {
     "name": "Can"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ codex --plugin-dir /path/to/agent-skills
 
 ## Changelog
 
+### 1.20.1
+
+- Fixed `zeabur-server-rent`, `zeabur-server-ssh`, `zeabur-server-list`, `zeabur-deploy`, and `zeabur-project-create` — renting a server now provisions a clean VPS with no Zeabur services, so the skills no longer assume a rented server can host projects or that `kubectl` is present, and they explain how to convert a server to ZeaburOS
+
 ### 1.20.0
 
 - Added `zeabur-cluster-scale` — list, scale, add, and remove node pools on dedicated Kubernetes clusters (LKE/EKS) via the GraphQL API, with explicit priced confirmation before every change

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ codex --plugin-dir /path/to/agent-skills
 
 ### 1.20.1
 
-- Fixed `zeabur-server-rent`, `zeabur-server-ssh`, `zeabur-server-list`, `zeabur-deploy`, and `zeabur-project-create` — renting a server now provisions a clean VPS with no Zeabur services, so the skills no longer assume a rented server can host projects or that `kubectl` is present, and they explain how to convert a server to ZeaburOS
+- Fixed `zeabur-server-rent`, `zeabur-server-ssh`, `zeabur-server-list`, `zeabur-deploy`, and `zeabur-project-create` — renting a server now provisions a standard VPS with no Zeabur services, so the skills no longer assume a rented server can host projects or that `kubectl` is present, and they explain how to convert a server to ZeaburOS
 
 ### 1.20.0
 

--- a/plugins/zeabur/.codex-plugin/plugin.json
+++ b/plugins/zeabur/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/plugins/zeabur/skills/zeabur-deploy/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-deploy/SKILL.md
@@ -22,7 +22,13 @@ npx zeabur@latest project list -i=false --json
 
 ### Deploying to a Specific Dedicated Server
 
-If the user asks to deploy to a specific **server** (e.g. "deploy to my AWS Tokyo server"), do **NOT** SSH into the server. Zeabur dedicated servers are managed via the platform — you deploy services through the Zeabur CLI, not by manually placing files on the machine.
+If the user asks to deploy to a specific **server** (e.g. "deploy to my AWS Tokyo server"), do **NOT** SSH into the server. Servers running ZeaburOS are managed via the platform — you deploy services through the Zeabur CLI, not by manually placing files on the machine.
+
+> **Only ZeaburOS servers can host projects.** A rented server starts as a clean
+> VPS (base OS and SSH, no Zeabur services) and must be converted first —
+> dashboard → the server's page → **Convert in Settings**. If deploying to a
+> server fails because it has no Zeabur services, that is why; tell the user
+> instead of trying to set the machine up over SSH.
 
 To find the project bound to a server:
 

--- a/plugins/zeabur/skills/zeabur-project-create/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-project-create/SKILL.md
@@ -27,7 +27,7 @@ Present the server list to the user (show name, provider, and region for each) a
 
 The region code format is `server-<server-id>`, where `<server-id>` comes from the server list output.
 
-> Some templates (e.g. with `REQUIRE_DEDICATED_SERVER`) can only be deployed on dedicated servers. If you get `Unsupported template (code: REQUIRE_DEDICATED_SERVER)`, the user needs a server running **ZeaburOS**, then recreate the project with its region. Note that renting provisions a clean VPS with no Zeabur services — it must be converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**) before a project can be created on it.
+> Some templates (e.g. with `REQUIRE_DEDICATED_SERVER`) can only be deployed on dedicated servers. If you get `Unsupported template (code: REQUIRE_DEDICATED_SERVER)`, the user needs a server running **ZeaburOS**, then recreate the project with its region. Note that renting provisions a standard VPS with no Zeabur services — it must be converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**) before a project can be created on it.
 
 ## Create Project
 

--- a/plugins/zeabur/skills/zeabur-project-create/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-project-create/SKILL.md
@@ -27,7 +27,7 @@ Present the server list to the user (show name, provider, and region for each) a
 
 The region code format is `server-<server-id>`, where `<server-id>` comes from the server list output.
 
-> Some templates (e.g. with `REQUIRE_DEDICATED_SERVER`) can only be deployed on dedicated servers. If you get `Unsupported template (code: REQUIRE_DEDICATED_SERVER)`, rent a dedicated server and recreate the project with its region.
+> Some templates (e.g. with `REQUIRE_DEDICATED_SERVER`) can only be deployed on dedicated servers. If you get `Unsupported template (code: REQUIRE_DEDICATED_SERVER)`, the user needs a server running **ZeaburOS**, then recreate the project with its region. Note that renting provisions a clean VPS with no Zeabur services — it must be converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**) before a project can be created on it.
 
 ## Create Project
 

--- a/plugins/zeabur/skills/zeabur-server-list/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-list/SKILL.md
@@ -43,14 +43,14 @@ npx zeabur@latest server reboot <server-id> -y
 
 A server can host Zeabur projects **only once it runs ZeaburOS**. A project's `Region.ID` will be `server-<server-id>` when it is deployed on such a server.
 
-Renting now provisions a **clean VPS** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until it is converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**).
+Renting now provisions a **standard VPS** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until it is converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**).
 
 **On a ZeaburOS server:**
 
 - **To deploy a service**, use the `zeabur-deploy` skill with the project bound to that server — do NOT SSH in and manually set up web servers or copy files.
 - **SSH is for low-level debugging only** (e.g. checking kubectl, inspecting disk, network diagnostics). It is not needed for deploying or managing services.
 
-**On a clean VPS:** SSH is not a debugging side-channel, it is the whole point — the machine is the user's to set up as they like (docker compose, 1Panel, 寶塔, …). There are no Zeabur services to manage, and `kubectl` does not exist.
+**On a standard VPS:** SSH is not a debugging side-channel, it is the whole point — the machine is the user's to set up as they like (docker compose, 1Panel, 寶塔, …). There are no Zeabur services to manage, and `kubectl` does not exist.
 
 ## SSH into a Server
 
@@ -58,7 +58,7 @@ Renting now provisions a **clean VPS** — base OS and SSH, no Zeabur services �
 npx zeabur@latest server ssh <server-id>
 ```
 
-> The `kubectl` examples below assume a **ZeaburOS** server. On a clean VPS they
+> The `kubectl` examples below assume a **ZeaburOS** server. On a standard VPS they
 > fail with `command not found` — see the `zeabur-server-ssh` skill for how to
 > tell the two apart.
 

--- a/plugins/zeabur/skills/zeabur-server-list/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-list/SKILL.md
@@ -41,16 +41,26 @@ npx zeabur@latest server reboot <server-id> -y
 
 ## Servers and Projects
 
-Each dedicated server can have Zeabur projects bound to it. A project's `Region.ID` will be `server-<server-id>` when it is deployed on a dedicated server.
+A server can host Zeabur projects **only once it runs ZeaburOS**. A project's `Region.ID` will be `server-<server-id>` when it is deployed on such a server.
 
-- **To deploy a service to a server**, use the `zeabur-deploy` skill with the project bound to that server — do NOT SSH in and manually set up web servers or copy files.
+Renting now provisions a **clean VPS** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until it is converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**).
+
+**On a ZeaburOS server:**
+
+- **To deploy a service**, use the `zeabur-deploy` skill with the project bound to that server — do NOT SSH in and manually set up web servers or copy files.
 - **SSH is for low-level debugging only** (e.g. checking kubectl, inspecting disk, network diagnostics). It is not needed for deploying or managing services.
 
-## SSH into a Server (Debugging Only)
+**On a clean VPS:** SSH is not a debugging side-channel, it is the whole point — the machine is the user's to set up as they like (docker compose, 1Panel, 寶塔, …). There are no Zeabur services to manage, and `kubectl` does not exist.
+
+## SSH into a Server
 
 ```bash
 npx zeabur@latest server ssh <server-id>
 ```
+
+> The `kubectl` examples below assume a **ZeaburOS** server. On a clean VPS they
+> fail with `command not found` — see the `zeabur-server-ssh` skill for how to
+> tell the two apart.
 
 For managed servers, the password is fetched automatically. If `sshpass` is installed, login is fully automatic; otherwise the password is printed for manual entry.
 

--- a/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
@@ -7,13 +7,13 @@ description: Use when renting a new dedicated server. Use when user wants to buy
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
 
-## What renting gives you: a clean VPS
+## What renting gives you: a standard VPS
 
-`server rent` provisions a **clean machine** — base OS and SSH, nothing else. Zeabur services (k3s) are **not** installed, so a freshly rented server **cannot host Zeabur projects yet**.
+`server rent` provisions a **standard VPS** — base OS and SSH, nothing else. Zeabur services are **not** installed, so a freshly rented server **cannot host Zeabur projects yet**.
 
-This is intentional, not a failure. The machine is the user's to do as they please: docker compose, 1Panel, 寶塔, or anything else. Installing Zeabur services is a separate, optional step they choose afterwards.
+This is intentional, not a failure. The machine is the user's to do as they please: docker compose, 1Panel, 寶塔, or anything else — a fully self-managed VPS. Running **ZeaburOS** (Zeabur's managed environment, built on k3s) is a separate, optional choice they make afterwards.
 
-Tell the user this when they rent, so a clean machine is never mistaken for a broken one.
+Tell the user this when they rent, so a standard VPS is never mistaken for a broken one.
 
 ## ⚠️ Renting charges real money — explicit confirmation is REQUIRED
 

--- a/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
@@ -7,6 +7,14 @@ description: Use when renting a new dedicated server. Use when user wants to buy
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
 
+## What renting gives you: a clean VPS
+
+`server rent` provisions a **clean machine** — base OS and SSH, nothing else. Zeabur services (k3s) are **not** installed, so a freshly rented server **cannot host Zeabur projects yet**.
+
+This is intentional, not a failure. The machine is the user's to do as they please: docker compose, 1Panel, 寶塔, or anything else. Installing Zeabur services is a separate, optional step they choose afterwards.
+
+Tell the user this when they rent, so a clean machine is never mistaken for a broken one.
+
 ## ⚠️ Renting charges real money — explicit confirmation is REQUIRED
 
 `server rent` immediately charges the user's payment method (or Zeabur balance). The `-y` flag skips the CLI's own confirmation prompt, so **you are the last line of defense**: never run `server rent` until the user has explicitly confirmed the exact priced option.
@@ -72,5 +80,23 @@ The server takes a few minutes to provision. Check status with:
 npx zeabur@latest server get <server-id> -i=false
 ```
 
-Look for `provisioningStatus` to change to `READY` and `VM STATUS` to `RUNNING`. Once ready, use the `zeabur-project-create` skill to create a project on the new server.
+Wait for `provisioningStatus` to become `READY` and `VM STATUS` to become `RUNNING`.
+
+Then follow whichever path matches what the user wants:
+
+### Use it as a plain VPS
+
+Nothing else is needed — SSH in and set the machine up however they like (docker compose, 1Panel, 寶塔, …). Use the `zeabur-server-ssh` skill:
+
+```bash
+npx zeabur@latest server exec --id <server-id> -- <command>
+```
+
+### Deploy Zeabur projects on it
+
+The server must first be converted to **ZeaburOS**, which installs the Zeabur services (k3s) that projects are deployed onto.
+
+**The CLI has no command for this yet.** Direct the user to the Zeabur dashboard → the server's page → **Convert in Settings**. Once the conversion finishes, the `zeabur-project-create` skill works against this server.
+
+> **Do not run `zeabur-project-create` against a freshly rented server.** It has no Zeabur services, so creating a project on it will fail. Convert it first.
 

--- a/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
@@ -7,7 +7,24 @@ description: Use when debugging services on a user's dedicated server via SSH. U
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method.
 
-Run commands on a user's dedicated server and use kubectl to debug Kubernetes workloads. Zeabur dedicated servers run k3s with kubectl pre-installed.
+Run commands on a user's dedicated server, and use kubectl to debug Kubernetes
+workloads on servers that run ZeaburOS.
+
+## Check which kind of server you are on before using kubectl
+
+- **ZeaburOS servers** run k3s with kubectl pre-installed. Everything in this
+  skill applies.
+- **Clean VPS** — a rented server that has not been converted to ZeaburOS. It has
+  **no k3s and no kubectl**; every `kubectl` command below fails with
+  `command not found`. `server exec` still works for ordinary shell commands.
+
+**Renting now provisions a clean VPS**, so never assume kubectl exists. If a
+`kubectl` command fails with `command not found`, the server is a clean VPS —
+tell the user that (and that converting it to ZeaburOS in the dashboard is what
+adds kubectl) instead of retrying the command.
+
+> The CLI does not yet expose which kind a server is. Until it does, infer it
+> from the failure above, or check the server's page in the Zeabur dashboard.
 
 ## Run a command: `server exec` (recommended)
 
@@ -43,6 +60,9 @@ Notes:
   (or use the `zeabur-server-list` skill).
 
 ## Common kubectl Commands
+
+> **ZeaburOS servers only.** On a clean VPS these all fail with
+> `kubectl: command not found` — see the section above.
 
 Pass any of these as the command to `server exec`. **Always use `sudo kubectl`** —
 the SSH user may not have direct access to the k3s kubeconfig. Any command with a

--- a/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
@@ -14,12 +14,12 @@ workloads on servers that run ZeaburOS.
 
 - **ZeaburOS servers** run k3s with kubectl pre-installed. Everything in this
   skill applies.
-- **Clean VPS** — a rented server that has not been converted to ZeaburOS. It has
+- **Standard VPS** — a rented server that is not running ZeaburOS. It has
   **no k3s and no kubectl**; every `kubectl` command below fails with
   `command not found`. `server exec` still works for ordinary shell commands.
 
-**Renting now provisions a clean VPS**, so never assume kubectl exists. If a
-`kubectl` command fails with `command not found`, the server is a clean VPS —
+**Renting now provisions a standard VPS**, so never assume kubectl exists. If a
+`kubectl` command fails with `command not found`, the server is a standard VPS —
 tell the user that (and that converting it to ZeaburOS in the dashboard is what
 adds kubectl) instead of retrying the command.
 
@@ -61,7 +61,7 @@ Notes:
 
 ## Common kubectl Commands
 
-> **ZeaburOS servers only.** On a clean VPS these all fail with
+> **ZeaburOS servers only.** On a standard VPS these all fail with
 > `kubectl: command not found` — see the section above.
 
 Pass any of these as the command to `server exec`. **Always use `sudo kubectl`** —

--- a/skills/zeabur-deploy/SKILL.md
+++ b/skills/zeabur-deploy/SKILL.md
@@ -22,7 +22,13 @@ npx zeabur@latest project list -i=false --json
 
 ### Deploying to a Specific Dedicated Server
 
-If the user asks to deploy to a specific **server** (e.g. "deploy to my AWS Tokyo server"), do **NOT** SSH into the server. Zeabur dedicated servers are managed via the platform — you deploy services through the Zeabur CLI, not by manually placing files on the machine.
+If the user asks to deploy to a specific **server** (e.g. "deploy to my AWS Tokyo server"), do **NOT** SSH into the server. Servers running ZeaburOS are managed via the platform — you deploy services through the Zeabur CLI, not by manually placing files on the machine.
+
+> **Only ZeaburOS servers can host projects.** A rented server starts as a clean
+> VPS (base OS and SSH, no Zeabur services) and must be converted first —
+> dashboard → the server's page → **Convert in Settings**. If deploying to a
+> server fails because it has no Zeabur services, that is why; tell the user
+> instead of trying to set the machine up over SSH.
 
 To find the project bound to a server:
 

--- a/skills/zeabur-project-create/SKILL.md
+++ b/skills/zeabur-project-create/SKILL.md
@@ -27,7 +27,7 @@ Present the server list to the user (show name, provider, and region for each) a
 
 The region code format is `server-<server-id>`, where `<server-id>` comes from the server list output.
 
-> Some templates (e.g. with `REQUIRE_DEDICATED_SERVER`) can only be deployed on dedicated servers. If you get `Unsupported template (code: REQUIRE_DEDICATED_SERVER)`, the user needs a server running **ZeaburOS**, then recreate the project with its region. Note that renting provisions a clean VPS with no Zeabur services — it must be converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**) before a project can be created on it.
+> Some templates (e.g. with `REQUIRE_DEDICATED_SERVER`) can only be deployed on dedicated servers. If you get `Unsupported template (code: REQUIRE_DEDICATED_SERVER)`, the user needs a server running **ZeaburOS**, then recreate the project with its region. Note that renting provisions a standard VPS with no Zeabur services — it must be converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**) before a project can be created on it.
 
 ## Create Project
 

--- a/skills/zeabur-project-create/SKILL.md
+++ b/skills/zeabur-project-create/SKILL.md
@@ -27,7 +27,7 @@ Present the server list to the user (show name, provider, and region for each) a
 
 The region code format is `server-<server-id>`, where `<server-id>` comes from the server list output.
 
-> Some templates (e.g. with `REQUIRE_DEDICATED_SERVER`) can only be deployed on dedicated servers. If you get `Unsupported template (code: REQUIRE_DEDICATED_SERVER)`, rent a dedicated server and recreate the project with its region.
+> Some templates (e.g. with `REQUIRE_DEDICATED_SERVER`) can only be deployed on dedicated servers. If you get `Unsupported template (code: REQUIRE_DEDICATED_SERVER)`, the user needs a server running **ZeaburOS**, then recreate the project with its region. Note that renting provisions a clean VPS with no Zeabur services — it must be converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**) before a project can be created on it.
 
 ## Create Project
 

--- a/skills/zeabur-server-list/SKILL.md
+++ b/skills/zeabur-server-list/SKILL.md
@@ -43,14 +43,14 @@ npx zeabur@latest server reboot <server-id> -y
 
 A server can host Zeabur projects **only once it runs ZeaburOS**. A project's `Region.ID` will be `server-<server-id>` when it is deployed on such a server.
 
-Renting now provisions a **clean VPS** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until it is converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**).
+Renting now provisions a **standard VPS** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until it is converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**).
 
 **On a ZeaburOS server:**
 
 - **To deploy a service**, use the `zeabur-deploy` skill with the project bound to that server — do NOT SSH in and manually set up web servers or copy files.
 - **SSH is for low-level debugging only** (e.g. checking kubectl, inspecting disk, network diagnostics). It is not needed for deploying or managing services.
 
-**On a clean VPS:** SSH is not a debugging side-channel, it is the whole point — the machine is the user's to set up as they like (docker compose, 1Panel, 寶塔, …). There are no Zeabur services to manage, and `kubectl` does not exist.
+**On a standard VPS:** SSH is not a debugging side-channel, it is the whole point — the machine is the user's to set up as they like (docker compose, 1Panel, 寶塔, …). There are no Zeabur services to manage, and `kubectl` does not exist.
 
 ## SSH into a Server
 
@@ -58,7 +58,7 @@ Renting now provisions a **clean VPS** — base OS and SSH, no Zeabur services �
 npx zeabur@latest server ssh <server-id>
 ```
 
-> The `kubectl` examples below assume a **ZeaburOS** server. On a clean VPS they
+> The `kubectl` examples below assume a **ZeaburOS** server. On a standard VPS they
 > fail with `command not found` — see the `zeabur-server-ssh` skill for how to
 > tell the two apart.
 

--- a/skills/zeabur-server-list/SKILL.md
+++ b/skills/zeabur-server-list/SKILL.md
@@ -41,16 +41,26 @@ npx zeabur@latest server reboot <server-id> -y
 
 ## Servers and Projects
 
-Each dedicated server can have Zeabur projects bound to it. A project's `Region.ID` will be `server-<server-id>` when it is deployed on a dedicated server.
+A server can host Zeabur projects **only once it runs ZeaburOS**. A project's `Region.ID` will be `server-<server-id>` when it is deployed on such a server.
 
-- **To deploy a service to a server**, use the `zeabur-deploy` skill with the project bound to that server — do NOT SSH in and manually set up web servers or copy files.
+Renting now provisions a **clean VPS** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until it is converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**).
+
+**On a ZeaburOS server:**
+
+- **To deploy a service**, use the `zeabur-deploy` skill with the project bound to that server — do NOT SSH in and manually set up web servers or copy files.
 - **SSH is for low-level debugging only** (e.g. checking kubectl, inspecting disk, network diagnostics). It is not needed for deploying or managing services.
 
-## SSH into a Server (Debugging Only)
+**On a clean VPS:** SSH is not a debugging side-channel, it is the whole point — the machine is the user's to set up as they like (docker compose, 1Panel, 寶塔, …). There are no Zeabur services to manage, and `kubectl` does not exist.
+
+## SSH into a Server
 
 ```bash
 npx zeabur@latest server ssh <server-id>
 ```
+
+> The `kubectl` examples below assume a **ZeaburOS** server. On a clean VPS they
+> fail with `command not found` — see the `zeabur-server-ssh` skill for how to
+> tell the two apart.
 
 For managed servers, the password is fetched automatically. If `sshpass` is installed, login is fully automatic; otherwise the password is printed for manual entry.
 

--- a/skills/zeabur-server-rent/SKILL.md
+++ b/skills/zeabur-server-rent/SKILL.md
@@ -7,13 +7,13 @@ description: Use when renting a new dedicated server. Use when user wants to buy
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
 
-## What renting gives you: a clean VPS
+## What renting gives you: a standard VPS
 
-`server rent` provisions a **clean machine** — base OS and SSH, nothing else. Zeabur services (k3s) are **not** installed, so a freshly rented server **cannot host Zeabur projects yet**.
+`server rent` provisions a **standard VPS** — base OS and SSH, nothing else. Zeabur services are **not** installed, so a freshly rented server **cannot host Zeabur projects yet**.
 
-This is intentional, not a failure. The machine is the user's to do as they please: docker compose, 1Panel, 寶塔, or anything else. Installing Zeabur services is a separate, optional step they choose afterwards.
+This is intentional, not a failure. The machine is the user's to do as they please: docker compose, 1Panel, 寶塔, or anything else — a fully self-managed VPS. Running **ZeaburOS** (Zeabur's managed environment, built on k3s) is a separate, optional choice they make afterwards.
 
-Tell the user this when they rent, so a clean machine is never mistaken for a broken one.
+Tell the user this when they rent, so a standard VPS is never mistaken for a broken one.
 
 ## ⚠️ Renting charges real money — explicit confirmation is REQUIRED
 

--- a/skills/zeabur-server-rent/SKILL.md
+++ b/skills/zeabur-server-rent/SKILL.md
@@ -7,6 +7,14 @@ description: Use when renting a new dedicated server. Use when user wants to buy
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
 
+## What renting gives you: a clean VPS
+
+`server rent` provisions a **clean machine** — base OS and SSH, nothing else. Zeabur services (k3s) are **not** installed, so a freshly rented server **cannot host Zeabur projects yet**.
+
+This is intentional, not a failure. The machine is the user's to do as they please: docker compose, 1Panel, 寶塔, or anything else. Installing Zeabur services is a separate, optional step they choose afterwards.
+
+Tell the user this when they rent, so a clean machine is never mistaken for a broken one.
+
 ## ⚠️ Renting charges real money — explicit confirmation is REQUIRED
 
 `server rent` immediately charges the user's payment method (or Zeabur balance). The `-y` flag skips the CLI's own confirmation prompt, so **you are the last line of defense**: never run `server rent` until the user has explicitly confirmed the exact priced option.
@@ -72,5 +80,23 @@ The server takes a few minutes to provision. Check status with:
 npx zeabur@latest server get <server-id> -i=false
 ```
 
-Look for `provisioningStatus` to change to `READY` and `VM STATUS` to `RUNNING`. Once ready, use the `zeabur-project-create` skill to create a project on the new server.
+Wait for `provisioningStatus` to become `READY` and `VM STATUS` to become `RUNNING`.
+
+Then follow whichever path matches what the user wants:
+
+### Use it as a plain VPS
+
+Nothing else is needed — SSH in and set the machine up however they like (docker compose, 1Panel, 寶塔, …). Use the `zeabur-server-ssh` skill:
+
+```bash
+npx zeabur@latest server exec --id <server-id> -- <command>
+```
+
+### Deploy Zeabur projects on it
+
+The server must first be converted to **ZeaburOS**, which installs the Zeabur services (k3s) that projects are deployed onto.
+
+**The CLI has no command for this yet.** Direct the user to the Zeabur dashboard → the server's page → **Convert in Settings**. Once the conversion finishes, the `zeabur-project-create` skill works against this server.
+
+> **Do not run `zeabur-project-create` against a freshly rented server.** It has no Zeabur services, so creating a project on it will fail. Convert it first.
 

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -7,7 +7,24 @@ description: Use when debugging services on a user's dedicated server via SSH. U
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method.
 
-Run commands on a user's dedicated server and use kubectl to debug Kubernetes workloads. Zeabur dedicated servers run k3s with kubectl pre-installed.
+Run commands on a user's dedicated server, and use kubectl to debug Kubernetes
+workloads on servers that run ZeaburOS.
+
+## Check which kind of server you are on before using kubectl
+
+- **ZeaburOS servers** run k3s with kubectl pre-installed. Everything in this
+  skill applies.
+- **Clean VPS** — a rented server that has not been converted to ZeaburOS. It has
+  **no k3s and no kubectl**; every `kubectl` command below fails with
+  `command not found`. `server exec` still works for ordinary shell commands.
+
+**Renting now provisions a clean VPS**, so never assume kubectl exists. If a
+`kubectl` command fails with `command not found`, the server is a clean VPS —
+tell the user that (and that converting it to ZeaburOS in the dashboard is what
+adds kubectl) instead of retrying the command.
+
+> The CLI does not yet expose which kind a server is. Until it does, infer it
+> from the failure above, or check the server's page in the Zeabur dashboard.
 
 ## Run a command: `server exec` (recommended)
 
@@ -43,6 +60,9 @@ Notes:
   (or use the `zeabur-server-list` skill).
 
 ## Common kubectl Commands
+
+> **ZeaburOS servers only.** On a clean VPS these all fail with
+> `kubectl: command not found` — see the section above.
 
 Pass any of these as the command to `server exec`. **Always use `sudo kubectl`** —
 the SSH user may not have direct access to the k3s kubeconfig. Any command with a

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -14,12 +14,12 @@ workloads on servers that run ZeaburOS.
 
 - **ZeaburOS servers** run k3s with kubectl pre-installed. Everything in this
   skill applies.
-- **Clean VPS** — a rented server that has not been converted to ZeaburOS. It has
+- **Standard VPS** — a rented server that is not running ZeaburOS. It has
   **no k3s and no kubectl**; every `kubectl` command below fails with
   `command not found`. `server exec` still works for ordinary shell commands.
 
-**Renting now provisions a clean VPS**, so never assume kubectl exists. If a
-`kubectl` command fails with `command not found`, the server is a clean VPS —
+**Renting now provisions a standard VPS**, so never assume kubectl exists. If a
+`kubectl` command fails with `command not found`, the server is a standard VPS —
 tell the user that (and that converting it to ZeaburOS in the dashboard is what
 adds kubectl) instead of retrying the command.
 
@@ -61,7 +61,7 @@ Notes:
 
 ## Common kubectl Commands
 
-> **ZeaburOS servers only.** On a clean VPS these all fail with
+> **ZeaburOS servers only.** On a standard VPS these all fail with
 > `kubectl: command not found` — see the section above.
 
 Pass any of these as the command to `server exec`. **Always use `sudo kubectl`** —


### PR DESCRIPTION
## Summary

- Buying a server now offers a choice between **ZeaburOS** and a **standard distribution** such as Ubuntu, and the CLI's `server rent` provisions the latter — a standard VPS with no Zeabur services. Several skills still described the previous behaviour, where every server arrived ready to host projects, so an agent following them would rent a machine and then hit a failure it had no way to explain
- Fixed `zeabur-server-rent` — it ended by directing the agent to `zeabur-project-create`, which fails on a machine with no Zeabur services. It now states that renting yields a standard VPS by design, and splits the follow-up into using it as a self-managed VPS over SSH versus moving it to ZeaburOS first
- Fixed `zeabur-server-ssh` — it asserted that dedicated servers run k3s with kubectl pre-installed, which does not hold on a standard VPS, where every `kubectl` example in the skill fails. It now states which kind of server each section applies to, and tells the agent to report a standard VPS rather than retry when `kubectl` is missing
- Fixed `zeabur-server-list` — it claimed every dedicated server can have projects bound to it and that SSH is only for low-level debugging. On a standard VPS neither holds: it hosts nothing until it runs ZeaburOS, and SSH is the primary way to use the machine
- Fixed `zeabur-deploy` — a failed deploy to a standard VPS previously read as a platform fault, and the skill's "do not SSH in" guidance left the agent with no next step. It now names the actual cause
- Fixed `zeabur-project-create` — `REQUIRE_DEDICATED_SERVER` templates need a server running ZeaburOS; renting alone no longer satisfies that
- Wording follows the [ZeaburOS announcement](https://zeabur.com/changelogs/zeabur-os): **ZeaburOS** and **standard VPS / standard distribution**. Agents relay these words to users, so they need to match what the dashboard and changelog say
- Bump plugin to 1.20.1 and add the changelog entry

## Notes

The CLI does not currently expose whether a server runs ZeaburOS, and has no command to switch a server between the two. Until it does, the skills infer the server type from `kubectl` being missing, and point users to the dashboard. Both gaps are tracked separately, and the guidance will be tightened once the CLI covers them.

## Test plan

- [x] `node scripts/sync-codex-plugin.mjs` run; `plugins/zeabur/` mirror verified identical to root `skills/` for every skill
- [x] Grepped the repo to confirm none of the corrected assertions, and none of the non-product wording, remain in either copy
- [x] Version consistent across `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and the synced mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)