### PR TITLE
feat(skills): let agents install ZeaburOS after renting a server

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zeabur",
   "description": "Zeabur CLI skills for deployment, template management, and troubleshooting",
-  "version": "1.20.1",
+  "version": "1.21.0",
   "author": {
     "name": "Can"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.20.1",
+  "version": "1.21.0",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Agent skills for Zeabur CLI operations, deployment, and troubleshooting. Works with **Claude Code**, **OpenAI Codex**, and other agents supporting the SKILL.md format.
 
-**Current version: 1.16.0**
+**Current version: 1.21.0**
 
 ## Installation
 
@@ -46,7 +46,7 @@ codex --plugin-dir /path/to/agent-skills
 | `zeabur-restart` | Restart individual services | Restarting services or --env-id required error |
 | `zeabur-server-list` | List, get, reboot, and SSH into dedicated servers | Checking server status, IP, rebooting, or SSH access |
 | `zeabur-server-catalog` | Browse available server providers/regions/plans | User asks what servers are available to rent |
-| `zeabur-server-rent` | Rent a new dedicated server | User wants to buy or provision a server |
+| `zeabur-server-rent` | Rent a new dedicated server, and install ZeaburOS on it | User wants to buy or provision a server, or make one able to host Zeabur projects |
 | `zeabur-cluster-scale` | Scale dedicated Kubernetes clusters (LKE/EKS) via node pools | User wants to add/remove nodes or resize a cluster |
 | `zeabur-service-list` | List all services and get service IDs | Needing service IDs or checking existing services |
 | `zeabur-startup-order` | Fix connection errors from startup order | Service fails with connection refused to database/redis |
@@ -64,6 +64,12 @@ codex --plugin-dir /path/to/agent-skills
 | `zeabur-domain-registrant` | Manage registrant profiles for domain registration | Creating/updating contact info for domains |
 
 ## Changelog
+
+### 1.21.0
+
+- Improved `zeabur-server-rent` — renting now asks which OS the user wants, and can install **ZeaburOS** on the machine afterwards (previously it could only point the user at the dashboard)
+- Improved `zeabur-server-ssh` — check `hasK3s` up front to tell a ZeaburOS server from a plain Ubuntu one, instead of inferring it from a failed `kubectl` call
+- Updated `zeabur-server-list`, `zeabur-deploy`, and `zeabur-project-create` to match
 
 ### 1.20.1
 

--- a/plugins/zeabur/.codex-plugin/plugin.json
+++ b/plugins/zeabur/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.20.1",
+  "version": "1.21.0",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/plugins/zeabur/skills/zeabur-deploy/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-deploy/SKILL.md
@@ -24,11 +24,11 @@ npx zeabur@latest project list -i=false --json
 
 If the user asks to deploy to a specific **server** (e.g. "deploy to my AWS Tokyo server"), do **NOT** SSH into the server. Servers running ZeaburOS are managed via the platform — you deploy services through the Zeabur CLI, not by manually placing files on the machine.
 
-> **Only ZeaburOS servers can host projects.** A rented server starts as a clean
-> VPS (base OS and SSH, no Zeabur services) and must be converted first —
-> dashboard → the server's page → **Convert in Settings**. If deploying to a
-> server fails because it has no Zeabur services, that is why; tell the user
-> instead of trying to set the machine up over SSH.
+> **Only ZeaburOS servers can host projects.** A rented server starts as plain
+> Ubuntu (base OS and SSH, no Zeabur services); ZeaburOS has to be installed on
+> it first — see the `zeabur-server-rent` skill. If deploying to a server fails
+> because it has no Zeabur services, that is why; tell the user instead of
+> trying to set the machine up over SSH.
 
 To find the project bound to a server:
 

--- a/plugins/zeabur/skills/zeabur-project-create/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-project-create/SKILL.md
@@ -27,7 +27,7 @@ Present the server list to the user (show name, provider, and region for each) a
 
 The region code format is `server-<server-id>`, where `<server-id>` comes from the server list output.
 
-> Some templates (e.g. with `REQUIRE_DEDICATED_SERVER`) can only be deployed on dedicated servers. If you get `Unsupported template (code: REQUIRE_DEDICATED_SERVER)`, the user needs a server running **ZeaburOS**, then recreate the project with its region. Note that renting provisions a standard VPS with no Zeabur services — it must be converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**) before a project can be created on it.
+> Some templates (e.g. with `REQUIRE_DEDICATED_SERVER`) can only be deployed on dedicated servers. If you get `Unsupported template (code: REQUIRE_DEDICATED_SERVER)`, the user needs a server running **ZeaburOS**, then recreate the project with its region. Note that renting provisions Ubuntu with no Zeabur services — ZeaburOS must be installed on it (see the `zeabur-server-rent` skill) before a project can be created on it.
 
 ## Create Project
 

--- a/plugins/zeabur/skills/zeabur-server-list/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-list/SKILL.md
@@ -43,14 +43,14 @@ npx zeabur@latest server reboot <server-id> -y
 
 A server can host Zeabur projects **only once it runs ZeaburOS**. A project's `Region.ID` will be `server-<server-id>` when it is deployed on such a server.
 
-Renting now provisions a **standard VPS** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until it is converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**).
+Renting provisions **Ubuntu** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until ZeaburOS is installed on it. The `zeabur-server-rent` skill covers that step, and also how to check which kind a given server is (`hasK3s` via the API; the CLI does not report it yet).
 
 **On a ZeaburOS server:**
 
 - **To deploy a service**, use the `zeabur-deploy` skill with the project bound to that server — do NOT SSH in and manually set up web servers or copy files.
 - **SSH is for low-level debugging only** (e.g. checking kubectl, inspecting disk, network diagnostics). It is not needed for deploying or managing services.
 
-**On a standard VPS:** SSH is not a debugging side-channel, it is the whole point — the machine is the user's to set up as they like (docker compose, 1Panel, 寶塔, …). There are no Zeabur services to manage, and `kubectl` does not exist.
+**On a plain Ubuntu VPS:** SSH is not a debugging side-channel, it is the whole point — the machine is the user's to set up as they like (docker compose, 1Panel, 寶塔, …). There are no Zeabur services to manage, and `kubectl` does not exist.
 
 ## SSH into a Server
 
@@ -58,8 +58,8 @@ Renting now provisions a **standard VPS** — base OS and SSH, no Zeabur service
 npx zeabur@latest server ssh <server-id>
 ```
 
-> The `kubectl` examples below assume a **ZeaburOS** server. On a standard VPS they
-> fail with `command not found` — see the `zeabur-server-ssh` skill for how to
+> The `kubectl` examples below assume a **ZeaburOS** server. On a plain Ubuntu VPS
+> they fail with `command not found` — see the `zeabur-server-ssh` skill for how to
 > tell the two apart.
 
 For managed servers, the password is fetched automatically. If `sshpass` is installed, login is fully automatic; otherwise the password is printed for manual entry.

--- a/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
@@ -96,16 +96,22 @@ Works on any server that has no Zeabur services yet: one just rented, one reinst
 Keep the token out of the process list — write it into a `0600` curl config and pass that with `-K`, instead of putting `-H "Authorization: ..."` on the command line:
 
 ```bash
-TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml | awk '{print $2}')}"
+TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml 2>/dev/null | awk '{print $2}')}"
+if [ -z "$TOKEN" ]; then
+  echo "No Zeabur token found — set ZEABUR_API_KEY or run: npx zeabur@latest auth login" >&2
+  exit 1
+fi
 ZAPI_CFG=$(mktemp)
 chmod 600 "$ZAPI_CFG"
+trap 'rm -f "$ZAPI_CFG"' EXIT
 printf 'header = "Authorization: Bearer %s"\n' "$TOKEN" > "$ZAPI_CFG"
 unset TOKEN
 ```
 
 - Prefer the `ZEABUR_API_KEY` environment variable if set
 - Otherwise reuse the CLI token from `~/.config/zeabur/cli.yaml` (present after `npx zeabur@latest auth login` — use the `zeabur-auth` skill if the user is not logged in)
-- Each tool/Bash invocation is a fresh shell — run this setup in the same shell block as the requests that use `$ZAPI_CFG`, and `rm -f "$ZAPI_CFG"` when done
+- **Stop if no token was found.** Continuing sends an unauthenticated request, and the resulting `401` reads as "the server is broken" rather than "you are not logged in"
+- Each tool/Bash invocation is a fresh shell — run this setup in the same shell block as the requests that use `$ZAPI_CFG`. The `trap` removes the config even if a command in between fails
 
 ### Start the install
 
@@ -147,13 +153,15 @@ The mutation fails up front in these cases. Relay the meaning, not the raw Graph
 | `K3S_INSTALL_IN_PROGRESS` | An install is already running, or just finished | Do **not** send the mutation again — go straight to polling |
 | `SERVER_NOT_FOUND` | Wrong ID, or the server was deleted | Re-check the ID with `server list` |
 
-**If the mutation times out at the transport layer, never blind-retry.** The install may already be running server-side — poll the query above first, and only retry if `hasK3s` is still `false` and `provisioningStatus` is not `INITIALIZING`.
+**If the mutation times out at the transport layer, never blind-retry.** The install may already be running server-side. Poll the query above first, and only resend the mutation when the server is back in the documented pre-install state — `hasK3s: false` **and** `provisioningStatus: "READY"`.
+
+**Never auto-retry a `FAILED` install.** `FAILED` is terminal and means the install genuinely broke on the machine; retrying just repeats it. Report the failure and let the user decide.
 
 ## Payment Errors
 
 If the user has no credit card bound or insufficient balance, the CLI returns:
 
-```
+```text
 ERROR  Rent server failed: please bind a credit card or recharge credits first
 INFO   Please bind a credit card or top up your balance at: https://zeabur.com/account/billing
 ```

--- a/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
@@ -1,19 +1,32 @@
 ---
 name: zeabur-server-rent
-description: Use when renting a new dedicated server. Use when user wants to buy or provision a server. Supports discounted VPS from Linode, DigitalOcean, Hetzner, AWS Lightsail, GCP, Tencent Cloud (騰訊雲), Alibaba Cloud (阿里雲), and Volcano Engine (火山引擎).
+description: Use when renting a new dedicated server. Use when user wants to buy or provision a server. Use when the user wants a rented server to run ZeaburOS so it can host Zeabur projects. Supports discounted VPS from Linode, DigitalOcean, Hetzner, AWS Lightsail, GCP, Tencent Cloud (騰訊雲), Alibaba Cloud (阿里雲), and Volcano Engine (火山引擎).
 ---
 
 # Zeabur Server Rent
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
 
-## What renting gives you: a standard VPS
+## Renting provisions the base OS — ZeaburOS is a second step
 
-`server rent` provisions a **standard VPS** — base OS and SSH, nothing else. Zeabur services are **not** installed, so a freshly rented server **cannot host Zeabur projects yet**.
+`server rent` gives you **Ubuntu and SSH, nothing else**. Zeabur services are not installed, so a freshly rented server **cannot host Zeabur projects yet**.
 
-This is intentional, not a failure. The machine is the user's to do as they please: docker compose, 1Panel, 寶塔, or anything else — a fully self-managed VPS. Running **ZeaburOS** (Zeabur's managed environment, built on k3s) is a separate, optional choice they make afterwards.
+That is intentional, not a failure. The machine is the user's to do as they please: docker compose, 1Panel, 寶塔, or anything else. **ZeaburOS** — Zeabur's managed environment, built on k3s — is installed afterwards, as a separate step this skill also covers.
 
-Tell the user this when they rent, so a standard VPS is never mistaken for a broken one.
+## Ask which OS the user wants — before renting
+
+There are two outcomes, and they are not interchangeable. **Ask explicitly**; do not infer from context and do not pick a default:
+
+| Option | What it is | When |
+|--------|-----------|------|
+| **Ubuntu** | A plain, self-managed VPS. Renting finishes and you are done. | The user wants their own machine to set up however they like. |
+| **ZeaburOS** | Ubuntu plus Zeabur services. Required to deploy Zeabur projects onto this server. | The user wants to deploy projects on it. Adds a few minutes after renting. |
+
+Phrase it as a question, e.g.:
+
+> Do you want this server set up as **ZeaburOS** (so you can deploy Zeabur projects on it), or left as a plain **Ubuntu** VPS you manage yourself?
+
+"They said they want to deploy an app" is **not** an answer to this question — plenty of users deploy with docker compose on their own box. Ask anyway.
 
 ## ⚠️ Renting charges real money — explicit confirmation is REQUIRED
 
@@ -25,21 +38,16 @@ Before renting, you MUST present all of the following to the user in one message
 - **Region** (e.g. New York / `nyc3`)
 - **Plan/spec** (e.g. `s-2vcpu-4gb` — 2 vCPU / 4 GB RAM)
 - **Monthly price** (e.g. **US$27/month**)
+- **Which OS** they chose (from the step above)
 - That the charge happens **immediately** upon rental
 
 Then ask a direct yes/no question, for example:
 
-> You are about to rent DigitalOcean New York `s-2vcpu-4gb` for **US$27/month**. This will charge your payment method now. Confirm purchase?
+> You are about to rent DigitalOcean New York `s-2vcpu-4gb` for **US$27/month**, set up as **ZeaburOS**. This will charge your payment method now. Confirm purchase?
 
 Only proceed after the user clearly and affirmatively confirms **this specific priced option**.
 
 **Never infer purchase consent** from an ambiguous reply — a bare number like "2", an "ok", or a selection the user made before seeing concrete prices does NOT count. A numeric reply is only valid consent if it maps to a numbered option the user already saw with provider, region, spec, and price spelled out. When in doubt, re-confirm instead of renting.
-
-## Rent a Server
-
-```bash
-npx zeabur@latest server rent --provider <code> --region <id> --plan <name> -y -i=false
-```
 
 ## Workflow
 
@@ -51,15 +59,95 @@ npx zeabur@latest server catalog -i=false
 
 ### 2. Pick provider, region, plan from the JSON output
 
-### 3. Present the exact option (provider, region, spec, monthly price, immediate charge) and get the user's explicit confirmation
+### 3. Ask which OS the user wants
 
-See the confirmation requirements above. Do not skip this step even if the user previously asked you to rent a server in general terms.
+See the section above. This determines whether step 6 runs.
 
-### 4. Rent (only after confirmation)
+### 4. Present the exact option and get the user's explicit confirmation
+
+Provider, region, spec, monthly price, OS, immediate charge. Do not skip this step even if the user previously asked you to rent a server in general terms.
+
+### 5. Rent (only after confirmation)
 
 ```bash
 npx zeabur@latest server rent --provider hetzner --region fsn1 --plan CAX11 -y -i=false
 ```
+
+Provisioning takes a few minutes. Poll until the machine is up:
+
+```bash
+npx zeabur@latest server get <server-id> -i=false
+```
+
+Wait for `provisioningStatus` to become `READY` and `VM STATUS` to become `RUNNING`.
+
+### 6. If the user chose ZeaburOS: install Zeabur services
+
+Follow "Install ZeaburOS on a server" below. If they chose Ubuntu, you are done — see "Using a plain Ubuntu VPS".
+
+## Install ZeaburOS on a server
+
+Works on any server that has no Zeabur services yet: one just rented, one reinstalled back to base OS, or a WonderMesh device that stopped at joining the mesh.
+
+> **Not in the Zeabur CLI yet** — call the Zeabur GraphQL API directly at `https://api.zeabur.com/graphql`.
+
+### Authentication
+
+Keep the token out of the process list — write it into a `0600` curl config and pass that with `-K`, instead of putting `-H "Authorization: ..."` on the command line:
+
+```bash
+TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml | awk '{print $2}')}"
+ZAPI_CFG=$(mktemp)
+chmod 600 "$ZAPI_CFG"
+printf 'header = "Authorization: Bearer %s"\n' "$TOKEN" > "$ZAPI_CFG"
+unset TOKEN
+```
+
+- Prefer the `ZEABUR_API_KEY` environment variable if set
+- Otherwise reuse the CLI token from `~/.config/zeabur/cli.yaml` (present after `npx zeabur@latest auth login` — use the `zeabur-auth` skill if the user is not logged in)
+- Each tool/Bash invocation is a fresh shell — run this setup in the same shell block as the requests that use `$ZAPI_CFG`, and `rm -f "$ZAPI_CFG"` when done
+
+### Start the install
+
+```bash
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"mutation($id: ObjectID!) { installK3s(serverID: $id) }","variables":{"id":"<server-id>"}}'
+```
+
+**Returning does not mean the install finished.** The work runs in the background — SSH into the machine, install k3s, wait for the node to come up — and takes several minutes. A `true` response only means the install was accepted and started.
+
+### Poll until it finishes
+
+```bash
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"query($id: ObjectID!) { server(_id: $id) { hasK3s provisioningStatus } }","variables":{"id":"<server-id>"}}'
+```
+
+Poll every ~30 seconds and stop on one of:
+
+| Condition | Meaning |
+|-----------|---------|
+| `hasK3s: true` | **Done.** The server runs ZeaburOS and can host projects. |
+| `provisioningStatus: "FAILED"` | The install failed. Report it; do not blind-retry. |
+
+**Watch `hasK3s`, not `provisioningStatus: "READY"`.** The status goes `READY` → `INITIALIZING` → `READY`, so `READY` is also the state *before* the install starts — polling for it reports success the moment you look too early.
+
+**Bound the wait.** If it has not converged after ~15 minutes, stop polling and report the current state instead of waiting forever; the server's page in the Zeabur dashboard shows progress detail.
+
+### Errors
+
+The mutation fails up front in these cases. Relay the meaning, not the raw GraphQL error:
+
+| Code | What happened | What to tell the user |
+|------|---------------|-----------------------|
+| `K3S_ALREADY_INSTALLED` | The server already runs ZeaburOS | Nothing to do — it is ready for projects |
+| `SERVER_NOT_READY` | Still provisioning | Wait for `provisioningStatus: READY`, then retry |
+| `K3S_INSTALL_IN_PROGRESS` | An install is already running, or just finished | Do **not** send the mutation again — go straight to polling |
+| `SERVER_NOT_FOUND` | Wrong ID, or the server was deleted | Re-check the ID with `server list` |
+
+**If the mutation times out at the transport layer, never blind-retry.** The install may already be running server-side — poll the query above first, and only retry if `hasK3s` is still `false` and `provisioningStatus` is not `INITIALIZING`.
 
 ## Payment Errors
 
@@ -72,31 +160,14 @@ INFO   Please bind a credit card or top up your balance at: https://zeabur.com/a
 
 **Action:** Direct the user to https://zeabur.com/account/billing to add a payment method or top up balance, then retry.
 
-## After Renting
+## Using a plain Ubuntu VPS
 
-The server takes a few minutes to provision. Check status with:
-
-```bash
-npx zeabur@latest server get <server-id> -i=false
-```
-
-Wait for `provisioningStatus` to become `READY` and `VM STATUS` to become `RUNNING`.
-
-Then follow whichever path matches what the user wants:
-
-### Use it as a plain VPS
-
-Nothing else is needed — SSH in and set the machine up however they like (docker compose, 1Panel, 寶塔, …). Use the `zeabur-server-ssh` skill:
+Nothing else is needed — SSH in and set the machine up however the user likes (docker compose, 1Panel, 寶塔, …). Use the `zeabur-server-ssh` skill:
 
 ```bash
 npx zeabur@latest server exec --id <server-id> -- <command>
 ```
 
-### Deploy Zeabur projects on it
+`kubectl` does not exist on such a machine, and there are no Zeabur services to manage.
 
-The server must first be converted to **ZeaburOS**, which installs the Zeabur services (k3s) that projects are deployed onto.
-
-**The CLI has no command for this yet.** Direct the user to the Zeabur dashboard → the server's page → **Convert in Settings**. Once the conversion finishes, the `zeabur-project-create` skill works against this server.
-
-> **Do not run `zeabur-project-create` against a freshly rented server.** It has no Zeabur services, so creating a project on it will fail. Convert it first.
-
+> **Do not run `zeabur-project-create` against a server that is not running ZeaburOS.** It has no Zeabur services, so creating a project on it will fail — install ZeaburOS first.

--- a/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
@@ -14,17 +14,34 @@ workloads on servers that run ZeaburOS.
 
 - **ZeaburOS servers** run k3s with kubectl pre-installed. Everything in this
   skill applies.
-- **Standard VPS** — a rented server that is not running ZeaburOS. It has
+- **Ubuntu** — a rented server that is not running ZeaburOS. It has
   **no k3s and no kubectl**; every `kubectl` command below fails with
   `command not found`. `server exec` still works for ordinary shell commands.
 
-**Renting now provisions a standard VPS**, so never assume kubectl exists. If a
-`kubectl` command fails with `command not found`, the server is a standard VPS —
-tell the user that (and that converting it to ZeaburOS in the dashboard is what
-adds kubectl) instead of retrying the command.
+**Renting provisions Ubuntu only**, so never assume kubectl exists.
 
-> The CLI does not yet expose which kind a server is. Until it does, infer it
-> from the failure above, or check the server's page in the Zeabur dashboard.
+Check before connecting rather than guessing — query the API directly (see the
+`zeabur-server-rent` skill for the token setup that defines `$ZAPI_CFG`):
+
+```bash
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"query($id: ObjectID!) { server(_id: $id) { hasK3s } }","variables":{"id":"<server-id>"}}'
+```
+
+`hasK3s` is three-state, and the third state is a trap:
+
+- `true` — ZeaburOS. Everything in this skill applies.
+- `false` — Ubuntu only. No kubectl.
+- `null` — a server predating the field, which **does** run ZeaburOS.
+
+So the test is `hasK3s === false`, never `!hasK3s`: the latter sweeps in every
+older server and wrongly reports it as a plain VPS.
+
+If you did not check first and a `kubectl` command fails with `command not
+found`, that is the same signal — tell the user the server is a plain Ubuntu VPS
+instead of retrying the command. Installing ZeaburOS is what adds kubectl; the
+`zeabur-server-rent` skill covers how.
 
 ## Run a command: `server exec` (recommended)
 
@@ -61,7 +78,7 @@ Notes:
 
 ## Common kubectl Commands
 
-> **ZeaburOS servers only.** On a standard VPS these all fail with
+> **ZeaburOS servers only.** On a plain Ubuntu VPS these all fail with
 > `kubectl: command not found` — see the section above.
 
 Pass any of these as the command to `server exec`. **Always use `sudo kubectl`** —

--- a/skills/zeabur-deploy/SKILL.md
+++ b/skills/zeabur-deploy/SKILL.md
@@ -24,11 +24,11 @@ npx zeabur@latest project list -i=false --json
 
 If the user asks to deploy to a specific **server** (e.g. "deploy to my AWS Tokyo server"), do **NOT** SSH into the server. Servers running ZeaburOS are managed via the platform — you deploy services through the Zeabur CLI, not by manually placing files on the machine.
 
-> **Only ZeaburOS servers can host projects.** A rented server starts as a clean
-> VPS (base OS and SSH, no Zeabur services) and must be converted first —
-> dashboard → the server's page → **Convert in Settings**. If deploying to a
-> server fails because it has no Zeabur services, that is why; tell the user
-> instead of trying to set the machine up over SSH.
+> **Only ZeaburOS servers can host projects.** A rented server starts as plain
+> Ubuntu (base OS and SSH, no Zeabur services); ZeaburOS has to be installed on
+> it first — see the `zeabur-server-rent` skill. If deploying to a server fails
+> because it has no Zeabur services, that is why; tell the user instead of
+> trying to set the machine up over SSH.
 
 To find the project bound to a server:
 

--- a/skills/zeabur-project-create/SKILL.md
+++ b/skills/zeabur-project-create/SKILL.md
@@ -27,7 +27,7 @@ Present the server list to the user (show name, provider, and region for each) a
 
 The region code format is `server-<server-id>`, where `<server-id>` comes from the server list output.
 
-> Some templates (e.g. with `REQUIRE_DEDICATED_SERVER`) can only be deployed on dedicated servers. If you get `Unsupported template (code: REQUIRE_DEDICATED_SERVER)`, the user needs a server running **ZeaburOS**, then recreate the project with its region. Note that renting provisions a standard VPS with no Zeabur services — it must be converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**) before a project can be created on it.
+> Some templates (e.g. with `REQUIRE_DEDICATED_SERVER`) can only be deployed on dedicated servers. If you get `Unsupported template (code: REQUIRE_DEDICATED_SERVER)`, the user needs a server running **ZeaburOS**, then recreate the project with its region. Note that renting provisions Ubuntu with no Zeabur services — ZeaburOS must be installed on it (see the `zeabur-server-rent` skill) before a project can be created on it.
 
 ## Create Project
 

--- a/skills/zeabur-server-list/SKILL.md
+++ b/skills/zeabur-server-list/SKILL.md
@@ -43,14 +43,14 @@ npx zeabur@latest server reboot <server-id> -y
 
 A server can host Zeabur projects **only once it runs ZeaburOS**. A project's `Region.ID` will be `server-<server-id>` when it is deployed on such a server.
 
-Renting now provisions a **standard VPS** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until it is converted to ZeaburOS (dashboard → the server's page → **Convert in Settings**).
+Renting provisions **Ubuntu** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until ZeaburOS is installed on it. The `zeabur-server-rent` skill covers that step, and also how to check which kind a given server is (`hasK3s` via the API; the CLI does not report it yet).
 
 **On a ZeaburOS server:**
 
 - **To deploy a service**, use the `zeabur-deploy` skill with the project bound to that server — do NOT SSH in and manually set up web servers or copy files.
 - **SSH is for low-level debugging only** (e.g. checking kubectl, inspecting disk, network diagnostics). It is not needed for deploying or managing services.
 
-**On a standard VPS:** SSH is not a debugging side-channel, it is the whole point — the machine is the user's to set up as they like (docker compose, 1Panel, 寶塔, …). There are no Zeabur services to manage, and `kubectl` does not exist.
+**On a plain Ubuntu VPS:** SSH is not a debugging side-channel, it is the whole point — the machine is the user's to set up as they like (docker compose, 1Panel, 寶塔, …). There are no Zeabur services to manage, and `kubectl` does not exist.
 
 ## SSH into a Server
 
@@ -58,8 +58,8 @@ Renting now provisions a **standard VPS** — base OS and SSH, no Zeabur service
 npx zeabur@latest server ssh <server-id>
 ```
 
-> The `kubectl` examples below assume a **ZeaburOS** server. On a standard VPS they
-> fail with `command not found` — see the `zeabur-server-ssh` skill for how to
+> The `kubectl` examples below assume a **ZeaburOS** server. On a plain Ubuntu VPS
+> they fail with `command not found` — see the `zeabur-server-ssh` skill for how to
 > tell the two apart.
 
 For managed servers, the password is fetched automatically. If `sshpass` is installed, login is fully automatic; otherwise the password is printed for manual entry.

--- a/skills/zeabur-server-rent/SKILL.md
+++ b/skills/zeabur-server-rent/SKILL.md
@@ -96,16 +96,22 @@ Works on any server that has no Zeabur services yet: one just rented, one reinst
 Keep the token out of the process list — write it into a `0600` curl config and pass that with `-K`, instead of putting `-H "Authorization: ..."` on the command line:
 
 ```bash
-TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml | awk '{print $2}')}"
+TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml 2>/dev/null | awk '{print $2}')}"
+if [ -z "$TOKEN" ]; then
+  echo "No Zeabur token found — set ZEABUR_API_KEY or run: npx zeabur@latest auth login" >&2
+  exit 1
+fi
 ZAPI_CFG=$(mktemp)
 chmod 600 "$ZAPI_CFG"
+trap 'rm -f "$ZAPI_CFG"' EXIT
 printf 'header = "Authorization: Bearer %s"\n' "$TOKEN" > "$ZAPI_CFG"
 unset TOKEN
 ```
 
 - Prefer the `ZEABUR_API_KEY` environment variable if set
 - Otherwise reuse the CLI token from `~/.config/zeabur/cli.yaml` (present after `npx zeabur@latest auth login` — use the `zeabur-auth` skill if the user is not logged in)
-- Each tool/Bash invocation is a fresh shell — run this setup in the same shell block as the requests that use `$ZAPI_CFG`, and `rm -f "$ZAPI_CFG"` when done
+- **Stop if no token was found.** Continuing sends an unauthenticated request, and the resulting `401` reads as "the server is broken" rather than "you are not logged in"
+- Each tool/Bash invocation is a fresh shell — run this setup in the same shell block as the requests that use `$ZAPI_CFG`. The `trap` removes the config even if a command in between fails
 
 ### Start the install
 
@@ -147,13 +153,15 @@ The mutation fails up front in these cases. Relay the meaning, not the raw Graph
 | `K3S_INSTALL_IN_PROGRESS` | An install is already running, or just finished | Do **not** send the mutation again — go straight to polling |
 | `SERVER_NOT_FOUND` | Wrong ID, or the server was deleted | Re-check the ID with `server list` |
 
-**If the mutation times out at the transport layer, never blind-retry.** The install may already be running server-side — poll the query above first, and only retry if `hasK3s` is still `false` and `provisioningStatus` is not `INITIALIZING`.
+**If the mutation times out at the transport layer, never blind-retry.** The install may already be running server-side. Poll the query above first, and only resend the mutation when the server is back in the documented pre-install state — `hasK3s: false` **and** `provisioningStatus: "READY"`.
+
+**Never auto-retry a `FAILED` install.** `FAILED` is terminal and means the install genuinely broke on the machine; retrying just repeats it. Report the failure and let the user decide.
 
 ## Payment Errors
 
 If the user has no credit card bound or insufficient balance, the CLI returns:
 
-```
+```text
 ERROR  Rent server failed: please bind a credit card or recharge credits first
 INFO   Please bind a credit card or top up your balance at: https://zeabur.com/account/billing
 ```

--- a/skills/zeabur-server-rent/SKILL.md
+++ b/skills/zeabur-server-rent/SKILL.md
@@ -1,19 +1,32 @@
 ---
 name: zeabur-server-rent
-description: Use when renting a new dedicated server. Use when user wants to buy or provision a server. Supports discounted VPS from Linode, DigitalOcean, Hetzner, AWS Lightsail, GCP, Tencent Cloud (騰訊雲), Alibaba Cloud (阿里雲), and Volcano Engine (火山引擎).
+description: Use when renting a new dedicated server. Use when user wants to buy or provision a server. Use when the user wants a rented server to run ZeaburOS so it can host Zeabur projects. Supports discounted VPS from Linode, DigitalOcean, Hetzner, AWS Lightsail, GCP, Tencent Cloud (騰訊雲), Alibaba Cloud (阿里雲), and Volcano Engine (火山引擎).
 ---
 
 # Zeabur Server Rent
 
 > **Always use `npx zeabur@latest` to invoke Zeabur CLI.** Never use `zeabur` directly or any other installation method. If `npx` is not available, install Node.js first.
 
-## What renting gives you: a standard VPS
+## Renting provisions the base OS — ZeaburOS is a second step
 
-`server rent` provisions a **standard VPS** — base OS and SSH, nothing else. Zeabur services are **not** installed, so a freshly rented server **cannot host Zeabur projects yet**.
+`server rent` gives you **Ubuntu and SSH, nothing else**. Zeabur services are not installed, so a freshly rented server **cannot host Zeabur projects yet**.
 
-This is intentional, not a failure. The machine is the user's to do as they please: docker compose, 1Panel, 寶塔, or anything else — a fully self-managed VPS. Running **ZeaburOS** (Zeabur's managed environment, built on k3s) is a separate, optional choice they make afterwards.
+That is intentional, not a failure. The machine is the user's to do as they please: docker compose, 1Panel, 寶塔, or anything else. **ZeaburOS** — Zeabur's managed environment, built on k3s — is installed afterwards, as a separate step this skill also covers.
 
-Tell the user this when they rent, so a standard VPS is never mistaken for a broken one.
+## Ask which OS the user wants — before renting
+
+There are two outcomes, and they are not interchangeable. **Ask explicitly**; do not infer from context and do not pick a default:
+
+| Option | What it is | When |
+|--------|-----------|------|
+| **Ubuntu** | A plain, self-managed VPS. Renting finishes and you are done. | The user wants their own machine to set up however they like. |
+| **ZeaburOS** | Ubuntu plus Zeabur services. Required to deploy Zeabur projects onto this server. | The user wants to deploy projects on it. Adds a few minutes after renting. |
+
+Phrase it as a question, e.g.:
+
+> Do you want this server set up as **ZeaburOS** (so you can deploy Zeabur projects on it), or left as a plain **Ubuntu** VPS you manage yourself?
+
+"They said they want to deploy an app" is **not** an answer to this question — plenty of users deploy with docker compose on their own box. Ask anyway.
 
 ## ⚠️ Renting charges real money — explicit confirmation is REQUIRED
 
@@ -25,21 +38,16 @@ Before renting, you MUST present all of the following to the user in one message
 - **Region** (e.g. New York / `nyc3`)
 - **Plan/spec** (e.g. `s-2vcpu-4gb` — 2 vCPU / 4 GB RAM)
 - **Monthly price** (e.g. **US$27/month**)
+- **Which OS** they chose (from the step above)
 - That the charge happens **immediately** upon rental
 
 Then ask a direct yes/no question, for example:
 
-> You are about to rent DigitalOcean New York `s-2vcpu-4gb` for **US$27/month**. This will charge your payment method now. Confirm purchase?
+> You are about to rent DigitalOcean New York `s-2vcpu-4gb` for **US$27/month**, set up as **ZeaburOS**. This will charge your payment method now. Confirm purchase?
 
 Only proceed after the user clearly and affirmatively confirms **this specific priced option**.
 
 **Never infer purchase consent** from an ambiguous reply — a bare number like "2", an "ok", or a selection the user made before seeing concrete prices does NOT count. A numeric reply is only valid consent if it maps to a numbered option the user already saw with provider, region, spec, and price spelled out. When in doubt, re-confirm instead of renting.
-
-## Rent a Server
-
-```bash
-npx zeabur@latest server rent --provider <code> --region <id> --plan <name> -y -i=false
-```
 
 ## Workflow
 
@@ -51,15 +59,95 @@ npx zeabur@latest server catalog -i=false
 
 ### 2. Pick provider, region, plan from the JSON output
 
-### 3. Present the exact option (provider, region, spec, monthly price, immediate charge) and get the user's explicit confirmation
+### 3. Ask which OS the user wants
 
-See the confirmation requirements above. Do not skip this step even if the user previously asked you to rent a server in general terms.
+See the section above. This determines whether step 6 runs.
 
-### 4. Rent (only after confirmation)
+### 4. Present the exact option and get the user's explicit confirmation
+
+Provider, region, spec, monthly price, OS, immediate charge. Do not skip this step even if the user previously asked you to rent a server in general terms.
+
+### 5. Rent (only after confirmation)
 
 ```bash
 npx zeabur@latest server rent --provider hetzner --region fsn1 --plan CAX11 -y -i=false
 ```
+
+Provisioning takes a few minutes. Poll until the machine is up:
+
+```bash
+npx zeabur@latest server get <server-id> -i=false
+```
+
+Wait for `provisioningStatus` to become `READY` and `VM STATUS` to become `RUNNING`.
+
+### 6. If the user chose ZeaburOS: install Zeabur services
+
+Follow "Install ZeaburOS on a server" below. If they chose Ubuntu, you are done — see "Using a plain Ubuntu VPS".
+
+## Install ZeaburOS on a server
+
+Works on any server that has no Zeabur services yet: one just rented, one reinstalled back to base OS, or a WonderMesh device that stopped at joining the mesh.
+
+> **Not in the Zeabur CLI yet** — call the Zeabur GraphQL API directly at `https://api.zeabur.com/graphql`.
+
+### Authentication
+
+Keep the token out of the process list — write it into a `0600` curl config and pass that with `-K`, instead of putting `-H "Authorization: ..."` on the command line:
+
+```bash
+TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml | awk '{print $2}')}"
+ZAPI_CFG=$(mktemp)
+chmod 600 "$ZAPI_CFG"
+printf 'header = "Authorization: Bearer %s"\n' "$TOKEN" > "$ZAPI_CFG"
+unset TOKEN
+```
+
+- Prefer the `ZEABUR_API_KEY` environment variable if set
+- Otherwise reuse the CLI token from `~/.config/zeabur/cli.yaml` (present after `npx zeabur@latest auth login` — use the `zeabur-auth` skill if the user is not logged in)
+- Each tool/Bash invocation is a fresh shell — run this setup in the same shell block as the requests that use `$ZAPI_CFG`, and `rm -f "$ZAPI_CFG"` when done
+
+### Start the install
+
+```bash
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"mutation($id: ObjectID!) { installK3s(serverID: $id) }","variables":{"id":"<server-id>"}}'
+```
+
+**Returning does not mean the install finished.** The work runs in the background — SSH into the machine, install k3s, wait for the node to come up — and takes several minutes. A `true` response only means the install was accepted and started.
+
+### Poll until it finishes
+
+```bash
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"query($id: ObjectID!) { server(_id: $id) { hasK3s provisioningStatus } }","variables":{"id":"<server-id>"}}'
+```
+
+Poll every ~30 seconds and stop on one of:
+
+| Condition | Meaning |
+|-----------|---------|
+| `hasK3s: true` | **Done.** The server runs ZeaburOS and can host projects. |
+| `provisioningStatus: "FAILED"` | The install failed. Report it; do not blind-retry. |
+
+**Watch `hasK3s`, not `provisioningStatus: "READY"`.** The status goes `READY` → `INITIALIZING` → `READY`, so `READY` is also the state *before* the install starts — polling for it reports success the moment you look too early.
+
+**Bound the wait.** If it has not converged after ~15 minutes, stop polling and report the current state instead of waiting forever; the server's page in the Zeabur dashboard shows progress detail.
+
+### Errors
+
+The mutation fails up front in these cases. Relay the meaning, not the raw GraphQL error:
+
+| Code | What happened | What to tell the user |
+|------|---------------|-----------------------|
+| `K3S_ALREADY_INSTALLED` | The server already runs ZeaburOS | Nothing to do — it is ready for projects |
+| `SERVER_NOT_READY` | Still provisioning | Wait for `provisioningStatus: READY`, then retry |
+| `K3S_INSTALL_IN_PROGRESS` | An install is already running, or just finished | Do **not** send the mutation again — go straight to polling |
+| `SERVER_NOT_FOUND` | Wrong ID, or the server was deleted | Re-check the ID with `server list` |
+
+**If the mutation times out at the transport layer, never blind-retry.** The install may already be running server-side — poll the query above first, and only retry if `hasK3s` is still `false` and `provisioningStatus` is not `INITIALIZING`.
 
 ## Payment Errors
 
@@ -72,31 +160,14 @@ INFO   Please bind a credit card or top up your balance at: https://zeabur.com/a
 
 **Action:** Direct the user to https://zeabur.com/account/billing to add a payment method or top up balance, then retry.
 
-## After Renting
+## Using a plain Ubuntu VPS
 
-The server takes a few minutes to provision. Check status with:
-
-```bash
-npx zeabur@latest server get <server-id> -i=false
-```
-
-Wait for `provisioningStatus` to become `READY` and `VM STATUS` to become `RUNNING`.
-
-Then follow whichever path matches what the user wants:
-
-### Use it as a plain VPS
-
-Nothing else is needed — SSH in and set the machine up however they like (docker compose, 1Panel, 寶塔, …). Use the `zeabur-server-ssh` skill:
+Nothing else is needed — SSH in and set the machine up however the user likes (docker compose, 1Panel, 寶塔, …). Use the `zeabur-server-ssh` skill:
 
 ```bash
 npx zeabur@latest server exec --id <server-id> -- <command>
 ```
 
-### Deploy Zeabur projects on it
+`kubectl` does not exist on such a machine, and there are no Zeabur services to manage.
 
-The server must first be converted to **ZeaburOS**, which installs the Zeabur services (k3s) that projects are deployed onto.
-
-**The CLI has no command for this yet.** Direct the user to the Zeabur dashboard → the server's page → **Convert in Settings**. Once the conversion finishes, the `zeabur-project-create` skill works against this server.
-
-> **Do not run `zeabur-project-create` against a freshly rented server.** It has no Zeabur services, so creating a project on it will fail. Convert it first.
-
+> **Do not run `zeabur-project-create` against a server that is not running ZeaburOS.** It has no Zeabur services, so creating a project on it will fail — install ZeaburOS first.

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -14,17 +14,34 @@ workloads on servers that run ZeaburOS.
 
 - **ZeaburOS servers** run k3s with kubectl pre-installed. Everything in this
   skill applies.
-- **Standard VPS** — a rented server that is not running ZeaburOS. It has
+- **Ubuntu** — a rented server that is not running ZeaburOS. It has
   **no k3s and no kubectl**; every `kubectl` command below fails with
   `command not found`. `server exec` still works for ordinary shell commands.
 
-**Renting now provisions a standard VPS**, so never assume kubectl exists. If a
-`kubectl` command fails with `command not found`, the server is a standard VPS —
-tell the user that (and that converting it to ZeaburOS in the dashboard is what
-adds kubectl) instead of retrying the command.
+**Renting provisions Ubuntu only**, so never assume kubectl exists.
 
-> The CLI does not yet expose which kind a server is. Until it does, infer it
-> from the failure above, or check the server's page in the Zeabur dashboard.
+Check before connecting rather than guessing — query the API directly (see the
+`zeabur-server-rent` skill for the token setup that defines `$ZAPI_CFG`):
+
+```bash
+curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
+  -H "Content-Type: application/json" \
+  -d '{"query":"query($id: ObjectID!) { server(_id: $id) { hasK3s } }","variables":{"id":"<server-id>"}}'
+```
+
+`hasK3s` is three-state, and the third state is a trap:
+
+- `true` — ZeaburOS. Everything in this skill applies.
+- `false` — Ubuntu only. No kubectl.
+- `null` — a server predating the field, which **does** run ZeaburOS.
+
+So the test is `hasK3s === false`, never `!hasK3s`: the latter sweeps in every
+older server and wrongly reports it as a plain VPS.
+
+If you did not check first and a `kubectl` command fails with `command not
+found`, that is the same signal — tell the user the server is a plain Ubuntu VPS
+instead of retrying the command. Installing ZeaburOS is what adds kubectl; the
+`zeabur-server-rent` skill covers how.
 
 ## Run a command: `server exec` (recommended)
 
@@ -61,7 +78,7 @@ Notes:
 
 ## Common kubectl Commands
 
-> **ZeaburOS servers only.** On a standard VPS these all fail with
+> **ZeaburOS servers only.** On a plain Ubuntu VPS these all fail with
 > `kubectl: command not found` — see the section above.
 
 Pass any of these as the command to `server exec`. **Always use `sudo kubectl`** —


### PR DESCRIPTION
## Background

Renting a server provisions **Ubuntu** only — Zeabur services are not installed, so the machine cannot host Zeabur projects yet. That is deliberate: the machine is the user's to do as they please, and running **ZeaburOS** is a separate, optional choice.

The skills already described that split, but had nowhere to send the user except the dashboard, which an agent cannot drive. So a request like "rent me a server and deploy this" dead-ended halfway, with the agent correctly explaining the problem and unable to do anything about it.

## Changes

### `zeabur-server-rent` now covers the whole path

- **Asks which OS the user wants before renting**, and includes that choice in the purchase confirmation. Wanting to deploy an app is explicitly *not* treated as an answer — plenty of users deploy with docker compose on their own box — so the question is asked rather than inferred.
- **Installs ZeaburOS after provisioning** via the `installK3s` mutation, following the direct-API pattern already established by `zeabur-cluster-scale` (token written to a `0600` curl config, never passed on the command line).
- **Polls `hasK3s`, not `provisioningStatus: READY`.** The status goes `READY` → `INITIALIZING` → `READY`, so `READY` is also the state *before* the install starts; polling for it would report success the moment the agent looks too early. The wait is bounded, and stops on `FAILED`.
- **Maps the four up-front failures** (already installed / not ready / install in progress / not found) to what the user should actually do, instead of surfacing raw GraphQL errors. A mutation that times out at the transport layer must be re-checked rather than blind-retried, since the install may already be running.

### `zeabur-server-ssh` checks instead of guessing

It previously inferred a machine's kind from a `kubectl` call failing with `command not found` — a wasted round trip that also cannot be done before deciding whether to connect at all. It now queries `hasK3s` up front.

The field is three-state and the third state is a trap: `null` means a server predating the field, which **does** run ZeaburOS. So the test is `=== false`, never `!hasK3s` — the latter would sweep in every older server and mislabel it. The failed-call signal is kept as a fallback for when no check was made.

### Supporting updates

`zeabur-server-list`, `zeabur-deploy`, and `zeabur-project-create` are updated to match and no longer point at a dashboard-only conversion step. Terminology is aligned on **ZeaburOS** and **Ubuntu** throughout.

## Notes

- `plugins/zeabur/` regenerated with `node scripts/sync-codex-plugin.mjs`; CI drift check passes.
- Version bumped to **1.21.0** across all three manifests, with a README changelog entry. The README's "Current version" line was stale at 1.16.0 and is corrected as part of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787300456&installation_model_id=20298&pr_number=76&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F76&signature=fddd0a6f371957b30d4144b49c228b7490a2ebdb6b94a68e0f69d94416ab8764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing Ubuntu or ZeaburOS when renting servers.
  * Added guided ZeaburOS installation and status polling after rental.
  * Added explicit server-type checks before using Kubernetes commands.

* **Bug Fixes**
  * Clarified deployment and project-creation requirements for servers without ZeaburOS.
  * Strengthened payment confirmation details and handling for rental errors.

* **Documentation**
  * Updated server rental, deployment, SSH, listing, and project-creation guidance.
  * Updated plugin and documentation versions to 1.21.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->