### PR TITLE
fix(skills): read a server's OS from the CLI instead of SSHing in to guess

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zeabur",
   "description": "Zeabur CLI skills for deployment, template management, and troubleshooting",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "author": {
     "name": "Can"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Agent skills for Zeabur CLI operations, deployment, and troubleshooting. Works with **Claude Code**, **OpenAI Codex**, and other agents supporting the SKILL.md format.
 
-**Current version: 1.21.0**
+**Current version: 1.21.1**
 
 ## Installation
 
@@ -64,6 +64,11 @@ codex --plugin-dir /path/to/agent-skills
 | `zeabur-domain-registrant` | Manage registrant profiles for domain registration | Creating/updating contact info for domains |
 
 ## Changelog
+
+### 1.21.1
+
+- Fixed `zeabur-server-list` and `zeabur-server-ssh` — Zeabur CLI 0.21.0 reports each server's OS, so the skills now read it directly instead of saying the CLI cannot report it (which sent agents SSHing into every machine to work it out)
+- Improved `zeabur-project-create` — only offer servers running ZeaburOS as deploy targets
 
 ### 1.21.0
 

--- a/plugins/zeabur/.codex-plugin/plugin.json
+++ b/plugins/zeabur/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.21.0",
+  "version": "1.21.1",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/plugins/zeabur/skills/zeabur-project-create/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-project-create/SKILL.md
@@ -21,6 +21,8 @@ npx zeabur@latest server list -i=false --json
 
 Present the server list to the user (show name, provider, and region for each) and **ask them to pick one**. Do NOT choose a server on the user's behalf. Also offer the option to rent a new server if none of the existing ones are suitable.
 
+- **Only servers whose `os` is `ZeaburOS` can host projects.** Servers reporting `Ubuntu` have no Zeabur services; creating a project on one fails. Leave them out of the menu, or list them separately as "needs ZeaburOS installed first" — do not silently offer one as a deploy target.
+
 - If the user has **no servers**, use the `zeabur-server-catalog` skill to browse options, then the `zeabur-server-rent` skill to rent one.
 
 **Step 3 — Use the selected server ID with `server-` prefix as the region:**

--- a/plugins/zeabur/skills/zeabur-server-list/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-list/SKILL.md
@@ -15,12 +15,24 @@ npx zeabur@latest server list -i=false
 
 ## Output Example
 
+```text
+     ID              NAME        IP              PROVIDER   LOCATION         STATUS   VM STATUS   OS
+-----------------+-------------+---------------+----------+----------------+--------+-----------+----------
+ 6989b00fd42b...   my-server    103.45.67.89    Hetzner    Singapore, SG    Online   RUNNING     ZeaburOS
+ 6989b00fd42b...   dev-box      45.67.89.12     Vultr      Tokyo, JP        Online   RUNNING     Ubuntu
 ```
-     ID              NAME        IP              PROVIDER   LOCATION         STATUS   VM STATUS
------------------+-------------+---------------+----------+----------------+--------+----------
- 6989b00fd42b...   my-server    103.45.67.89    Hetzner    Singapore, SG    Online   RUNNING
- 6989b00fd42b...   dev-box      45.67.89.12     Vultr      Tokyo, JP        Online   RUNNING
+
+## Which servers can host Zeabur projects: read the OS column
+
+**`ZeaburOS` means the machine can host Zeabur projects; `Ubuntu` means it cannot** (not until ZeaburOS is installed on it). This is the authoritative answer — **do not SSH into a machine to work out which kind it is.**
+
+For machine-readable output, `--json` carries the same value as `os` on every server:
+
+```bash
+npx zeabur@latest server list -i=false --json | jq -r '.[] | "\(.Name)\t\(.os)"'
 ```
+
+> Requires CLI **0.21.0 or newer**. If the `OS` column and the `os` field are both absent, the CLI is older; either let `npx zeabur@latest` fetch the current version, or fall back to querying `hasK3s` through the API (see the `zeabur-server-ssh` skill, which documents that field's three-state trap).
 
 ## Get Server Details
 
@@ -29,7 +41,9 @@ npx zeabur@latest server list -i=false
 npx zeabur@latest server get <server-id> -i=false
 ```
 
-Shows detailed info: CPU/memory/disk usage, provider, location, managed status, creation time.
+Shows detailed info: OS, CPU/memory/disk usage, provider, location, managed status, creation time.
+
+Resource columns read `used/total` — CPU in millicores (`148/4000 m` is 0.15 of 4 cores), memory and disk in MB. A column showing `—` means the value was not measured, **not** that the machine has none.
 
 ## Reboot a Server
 
@@ -43,7 +57,7 @@ npx zeabur@latest server reboot <server-id> -y
 
 A server can host Zeabur projects **only once it runs ZeaburOS**. A project's `Region.ID` will be `server-<server-id>` when it is deployed on such a server.
 
-Renting provisions **Ubuntu** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until ZeaburOS is installed on it. The `zeabur-server-rent` skill covers that step, and also how to check which kind a given server is (`hasK3s` via the API; the CLI does not report it yet).
+Renting provisions **Ubuntu** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until ZeaburOS is installed on it. The `zeabur-server-rent` skill covers that step. Which kind a given server is, is answered by the **OS** column above.
 
 **On a ZeaburOS server:**
 

--- a/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-ssh/SKILL.md
@@ -20,28 +20,40 @@ workloads on servers that run ZeaburOS.
 
 **Renting provisions Ubuntu only**, so never assume kubectl exists.
 
-Check before connecting rather than guessing — query the API directly (see the
-`zeabur-server-rent` skill for the token setup that defines `$ZAPI_CFG`):
+**Read the machine's kind from the CLI — do not SSH in to work it out:**
 
 ```bash
-curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
-  -H "Content-Type: application/json" \
-  -d '{"query":"query($id: ObjectID!) { server(_id: $id) { hasK3s } }","variables":{"id":"<server-id>"}}'
+npx zeabur@latest server get <server-id> -i=false --json | jq -r .os
 ```
 
-`hasK3s` is three-state, and the third state is a trap:
+`ZeaburOS` or `Ubuntu`. `server list` reports the same thing for every server at
+once, as an `OS` column and an `os` field.
 
-- `true` — ZeaburOS. Everything in this skill applies.
-- `false` — Ubuntu only. No kubectl.
-- `null` — a server predating the field, which **does** run ZeaburOS.
-
-So the test is `hasK3s === false`, never `!hasK3s`: the latter sweeps in every
-older server and wrongly reports it as a plain VPS.
+> Needs CLI **0.21.0 or newer**. If `os` comes back `null`, the CLI is older —
+> either let `npx zeabur@latest` fetch the current version, or fall back to the
+> API (see the `zeabur-server-rent` skill for the token setup that defines
+> `$ZAPI_CFG`):
+>
+> ```bash
+> curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
+>   -H "Content-Type: application/json" \
+>   -d '{"query":"query($id: ObjectID!) { server(_id: $id) { hasK3s } }","variables":{"id":"<server-id>"}}'
+> ```
+>
+> `hasK3s` is three-state and the third state is a trap: `true` is ZeaburOS,
+> `false` is Ubuntu only, and `null` is a server predating the field — which
+> **does** run ZeaburOS. So the test is `hasK3s === false`, never `!hasK3s`; the
+> latter sweeps in every older server and wrongly reports it as a plain VPS.
 
 If you did not check first and a `kubectl` command fails with `command not
 found`, that is the same signal — tell the user the server is a plain Ubuntu VPS
 instead of retrying the command. Installing ZeaburOS is what adds kubectl; the
 `zeabur-server-rent` skill covers how.
+
+**One exception.** All of the above answers *what kind of machine this is*. If
+the user asks specifically whether some binary is present, check the machine —
+a ZeaburOS server always has `kubectl`, but a plain Ubuntu VPS may have had it
+installed by its owner, and the OS field cannot tell you that.
 
 ## Run a command: `server exec` (recommended)
 

--- a/skills/zeabur-project-create/SKILL.md
+++ b/skills/zeabur-project-create/SKILL.md
@@ -21,6 +21,8 @@ npx zeabur@latest server list -i=false --json
 
 Present the server list to the user (show name, provider, and region for each) and **ask them to pick one**. Do NOT choose a server on the user's behalf. Also offer the option to rent a new server if none of the existing ones are suitable.
 
+- **Only servers whose `os` is `ZeaburOS` can host projects.** Servers reporting `Ubuntu` have no Zeabur services; creating a project on one fails. Leave them out of the menu, or list them separately as "needs ZeaburOS installed first" — do not silently offer one as a deploy target.
+
 - If the user has **no servers**, use the `zeabur-server-catalog` skill to browse options, then the `zeabur-server-rent` skill to rent one.
 
 **Step 3 — Use the selected server ID with `server-` prefix as the region:**

--- a/skills/zeabur-server-list/SKILL.md
+++ b/skills/zeabur-server-list/SKILL.md
@@ -15,12 +15,24 @@ npx zeabur@latest server list -i=false
 
 ## Output Example
 
+```text
+     ID              NAME        IP              PROVIDER   LOCATION         STATUS   VM STATUS   OS
+-----------------+-------------+---------------+----------+----------------+--------+-----------+----------
+ 6989b00fd42b...   my-server    103.45.67.89    Hetzner    Singapore, SG    Online   RUNNING     ZeaburOS
+ 6989b00fd42b...   dev-box      45.67.89.12     Vultr      Tokyo, JP        Online   RUNNING     Ubuntu
 ```
-     ID              NAME        IP              PROVIDER   LOCATION         STATUS   VM STATUS
------------------+-------------+---------------+----------+----------------+--------+----------
- 6989b00fd42b...   my-server    103.45.67.89    Hetzner    Singapore, SG    Online   RUNNING
- 6989b00fd42b...   dev-box      45.67.89.12     Vultr      Tokyo, JP        Online   RUNNING
+
+## Which servers can host Zeabur projects: read the OS column
+
+**`ZeaburOS` means the machine can host Zeabur projects; `Ubuntu` means it cannot** (not until ZeaburOS is installed on it). This is the authoritative answer — **do not SSH into a machine to work out which kind it is.**
+
+For machine-readable output, `--json` carries the same value as `os` on every server:
+
+```bash
+npx zeabur@latest server list -i=false --json | jq -r '.[] | "\(.Name)\t\(.os)"'
 ```
+
+> Requires CLI **0.21.0 or newer**. If the `OS` column and the `os` field are both absent, the CLI is older; either let `npx zeabur@latest` fetch the current version, or fall back to querying `hasK3s` through the API (see the `zeabur-server-ssh` skill, which documents that field's three-state trap).
 
 ## Get Server Details
 
@@ -29,7 +41,9 @@ npx zeabur@latest server list -i=false
 npx zeabur@latest server get <server-id> -i=false
 ```
 
-Shows detailed info: CPU/memory/disk usage, provider, location, managed status, creation time.
+Shows detailed info: OS, CPU/memory/disk usage, provider, location, managed status, creation time.
+
+Resource columns read `used/total` — CPU in millicores (`148/4000 m` is 0.15 of 4 cores), memory and disk in MB. A column showing `—` means the value was not measured, **not** that the machine has none.
 
 ## Reboot a Server
 
@@ -43,7 +57,7 @@ npx zeabur@latest server reboot <server-id> -y
 
 A server can host Zeabur projects **only once it runs ZeaburOS**. A project's `Region.ID` will be `server-<server-id>` when it is deployed on such a server.
 
-Renting provisions **Ubuntu** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until ZeaburOS is installed on it. The `zeabur-server-rent` skill covers that step, and also how to check which kind a given server is (`hasK3s` via the API; the CLI does not report it yet).
+Renting provisions **Ubuntu** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until ZeaburOS is installed on it. The `zeabur-server-rent` skill covers that step. Which kind a given server is, is answered by the **OS** column above.
 
 **On a ZeaburOS server:**
 

--- a/skills/zeabur-server-ssh/SKILL.md
+++ b/skills/zeabur-server-ssh/SKILL.md
@@ -20,28 +20,40 @@ workloads on servers that run ZeaburOS.
 
 **Renting provisions Ubuntu only**, so never assume kubectl exists.
 
-Check before connecting rather than guessing — query the API directly (see the
-`zeabur-server-rent` skill for the token setup that defines `$ZAPI_CFG`):
+**Read the machine's kind from the CLI — do not SSH in to work it out:**
 
 ```bash
-curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
-  -H "Content-Type: application/json" \
-  -d '{"query":"query($id: ObjectID!) { server(_id: $id) { hasK3s } }","variables":{"id":"<server-id>"}}'
+npx zeabur@latest server get <server-id> -i=false --json | jq -r .os
 ```
 
-`hasK3s` is three-state, and the third state is a trap:
+`ZeaburOS` or `Ubuntu`. `server list` reports the same thing for every server at
+once, as an `OS` column and an `os` field.
 
-- `true` — ZeaburOS. Everything in this skill applies.
-- `false` — Ubuntu only. No kubectl.
-- `null` — a server predating the field, which **does** run ZeaburOS.
-
-So the test is `hasK3s === false`, never `!hasK3s`: the latter sweeps in every
-older server and wrongly reports it as a plain VPS.
+> Needs CLI **0.21.0 or newer**. If `os` comes back `null`, the CLI is older —
+> either let `npx zeabur@latest` fetch the current version, or fall back to the
+> API (see the `zeabur-server-rent` skill for the token setup that defines
+> `$ZAPI_CFG`):
+>
+> ```bash
+> curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
+>   -H "Content-Type: application/json" \
+>   -d '{"query":"query($id: ObjectID!) { server(_id: $id) { hasK3s } }","variables":{"id":"<server-id>"}}'
+> ```
+>
+> `hasK3s` is three-state and the third state is a trap: `true` is ZeaburOS,
+> `false` is Ubuntu only, and `null` is a server predating the field — which
+> **does** run ZeaburOS. So the test is `hasK3s === false`, never `!hasK3s`; the
+> latter sweeps in every older server and wrongly reports it as a plain VPS.
 
 If you did not check first and a `kubectl` command fails with `command not
 found`, that is the same signal — tell the user the server is a plain Ubuntu VPS
 instead of retrying the command. Installing ZeaburOS is what adds kubectl; the
 `zeabur-server-rent` skill covers how.
+
+**One exception.** All of the above answers *what kind of machine this is*. If
+the user asks specifically whether some binary is present, check the machine —
+a ZeaburOS server always has `kubectl`, but a plain Ubuntu VPS may have had it
+installed by its owner, and the OS field cannot tell you that.
 
 ## Run a command: `server exec` (recommended)
 


### PR DESCRIPTION
## Background

Zeabur CLI 0.21.0 reports each server's OS — an `OS` column in `server list` / `server get`, and an `os` field in their `--json` output.

`zeabur-server-list` still said the opposite: *"the CLI does not report it yet"*. That was true when it was written and stopped being true when the CLI shipped.

The effect was not merely stale prose. Asked which of four servers had `kubectl`, an agent loaded this skill, saw the OS column in the output, and then **SSHed into all four machines anyway** to determine what the column had already told it. The skill that does document checking first — `zeabur-server-ssh` — was never loaded, because the question was about a list of servers rather than about connecting to one.

## Changes

**`zeabur-server-list`**
- Documents the `OS` column as the authoritative answer to which machines can host projects, with the `--json` equivalent, and states outright not to SSH in to determine it.
- Sample output now shows the column (previously it predated the column and showed neither value).
- Explains the resource columns, since `—` means "not measured" rather than "none", and CPU in millicores otherwise reads as an implausibly large core count.

**`zeabur-server-ssh`**
- Checks via the CLI first. The API query for `hasK3s` — and its three-state trap, where `null` means an older server that **does** run ZeaburOS — drops to a fallback for CLIs older than 0.21.0.

**`zeabur-project-create`**
- Only offers ZeaburOS servers as deploy targets; `Ubuntu` ones are excluded or listed separately, rather than silently presented as valid choices.

## One nuance kept explicit

The OS field answers *what kind of machine this is*, not *whether a given binary exists*. A ZeaburOS server always has `kubectl`, but a plain Ubuntu VPS may have had it installed by its owner. `zeabur-server-ssh` now says so, so a question specifically about a binary still warrants checking the machine — the original SSH behaviour was defensible for that phrasing, just not for "which of these can I deploy to".

## Notes

- `plugins/zeabur/` regenerated with `node scripts/sync-codex-plugin.mjs`.
- Version bumped to **1.21.1** across all three manifests, with a README changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787302105&installation_model_id=20298&pr_number=77&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F77&signature=1e16ae9073cf5e44bdc31645b47131cea705c5d25a6b88d70c188d21db9edc82"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->