### PR TITLE
fix(skills): give the ZeaburOS install one block to copy, not three to assemble

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zeabur",
   "description": "Zeabur CLI skills for deployment, template management, and troubleshooting",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "author": {
     "name": "Can"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Agent skills for Zeabur CLI operations, deployment, and troubleshooting. Works with **Claude Code**, **OpenAI Codex**, and other agents supporting the SKILL.md format.
 
-**Current version: 1.21.1**
+**Current version: 1.21.2**
 
 ## Installation
 
@@ -64,6 +64,10 @@ codex --plugin-dir /path/to/agent-skills
 | `zeabur-domain-registrant` | Manage registrant profiles for domain registration | Creating/updating contact info for domains |
 
 ## Changelog
+
+### 1.21.2
+
+- Improved `zeabur-server-rent` — the ZeaburOS install is now one copy-pasteable block (authenticate, install, wait) instead of three fragments an agent had to assemble, with `jq` parsing rather than grepping raw JSON
 
 ### 1.21.1
 

--- a/plugins/zeabur/.codex-plugin/plugin.json
+++ b/plugins/zeabur/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.21.1",
+  "version": "1.21.2",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
@@ -98,6 +98,8 @@ One block: authenticate, start the install, wait for it. Substitute the server I
 ```bash
 SERVER_ID="<server-id>"
 
+command -v jq >/dev/null 2>&1 || { echo "jq is required to read the API responses" >&2; exit 1; }
+
 # Keep the token out of the process list: write it into a 0600 curl config
 # passed with -K, never as -H "Authorization: ..." on the command line.
 TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml 2>/dev/null | awk '{print $2}')}"
@@ -116,15 +118,27 @@ zapi() {
     -H "Content-Type: application/json" -d "$1"
 }
 
-# Start the install. This returns immediately — the work runs in the background.
-zapi "{\"query\":\"mutation(\$id: ObjectID!) { installK3s(serverID: \$id) }\",\"variables\":{\"id\":\"$SERVER_ID\"}}"
+# GraphQL reports failures as HTTP 200 with an `errors` array, so a request that
+# "succeeded" can still be a hard failure. Stop on one instead of polling past it.
+die_on_error() {
+  if printf '%s' "$1" | jq -e 'has("errors")' >/dev/null 2>&1; then
+    printf '%s' "$1" | jq -r '.errors[] | "\(.extensions.code // "ERROR"): \(.message)\(if .extensions.description then " — " + .extensions.description else "" end)"' >&2
+    exit 1
+  fi
+}
 
-# Wait for it: up to 15 minutes, checking every 30 seconds.
-for _ in $(seq 1 30); do
+# Start the install. This returns immediately — the work runs in the background.
+RESP=$(zapi "{\"query\":\"mutation(\$id: ObjectID!) { installK3s(serverID: \$id) }\",\"variables\":{\"id\":\"$SERVER_ID\"}}")
+die_on_error "$RESP"
+
+# Wait for it, against a real 15-minute deadline.
+DEADLINE=$(( $(date +%s) + 900 ))
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
   sleep 30
   RESP=$(zapi "{\"query\":\"query(\$id: ObjectID!) { server(_id: \$id) { hasK3s provisioningStatus } }\",\"variables\":{\"id\":\"$SERVER_ID\"}}")
-  HAS_K3S=$(printf '%s' "$RESP" | jq -r '.data.server.hasK3s')
-  STATUS=$(printf '%s' "$RESP" | jq -r '.data.server.provisioningStatus')
+  die_on_error "$RESP"
+  HAS_K3S=$(printf '%s' "$RESP" | jq -r '.data.server.hasK3s // "unknown"')
+  STATUS=$(printf '%s' "$RESP" | jq -r '.data.server.provisioningStatus // "unknown"')
   echo "hasK3s=$HAS_K3S provisioningStatus=$STATUS"
   if [ "$HAS_K3S" = "true" ]; then echo "ZeaburOS is installed"; exit 0; fi
   if [ "$STATUS" = "FAILED" ]; then echo "Install failed: $RESP" >&2; exit 1; fi
@@ -138,8 +152,9 @@ Why each part is the way it is:
 - **The mutation returning does not mean the install finished.** The work runs in the background — SSH into the machine, install k3s, wait for the node to come up — and takes several minutes. A `true` response only means it was accepted and started. Never report success off the mutation alone.
 - **Success is `hasK3s: true`, not `provisioningStatus: "READY"`.** The status goes `READY` → `INITIALIZING` → `READY`, so `READY` is also the state *before* the install starts. Polling for it reports success the moment you look too early — and it will look right, because the machine really is `READY`.
 - **`FAILED` is checked separately**, so a broken install ends the wait instead of running out the clock.
-- **Parse with `jq`, not by grepping the raw JSON.** `grep '"hasK3s":true'` breaks the moment the response is formatted with a space after the colon, and it fails *open* — a missed match looks like "still installing".
-- **The wait is bounded.** After 15 minutes, stop and report the current state rather than polling forever; the server's page in the dashboard shows progress detail.
+- **Every response is checked for `errors` first.** GraphQL returns failures as HTTP 200 with an `errors` array and no `data`, so an unauthorized token, a bad server ID, or any of the precondition failures below would otherwise read as "still installing" and burn the full 15 minutes before reporting nothing useful. `extensions.code` is the machine-readable code from the table below; `extensions.description` is the user-facing explanation.
+- **Parse with `jq`, not by grepping the raw JSON.** `grep '"hasK3s":true'` breaks the moment the response is formatted with a space after the colon, and it fails *open* — a missed match looks like "still installing". For the same reason the block refuses to start without `jq` rather than silently mis-parsing.
+- **The wait is a deadline, not a counter.** `30 × sleep 30` runs past 15 minutes once request time is added; comparing against a timestamp means the stated bound is the real one.
 - **Stop if no token was found.** Continuing sends an unauthenticated request, and the resulting `401` reads as "the server is broken" rather than "you are not logged in".
 - **The `trap` removes the curl config** even if a command in between fails. Each tool/Bash invocation is a fresh shell, so keep the whole block together — `$ZAPI_CFG` does not survive into the next one.
 

--- a/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
@@ -91,11 +91,15 @@ Works on any server that has no Zeabur services yet: one just rented, one reinst
 
 > **Not in the Zeabur CLI yet** — call the Zeabur GraphQL API directly at `https://api.zeabur.com/graphql`.
 
-### Authentication
+### Run this
 
-Keep the token out of the process list — write it into a `0600` curl config and pass that with `-K`, instead of putting `-H "Authorization: ..."` on the command line:
+One block: authenticate, start the install, wait for it. Substitute the server ID and run it as-is — every part of it is load-bearing, and the notes below say why.
 
 ```bash
+SERVER_ID="<server-id>"
+
+# Keep the token out of the process list: write it into a 0600 curl config
+# passed with -K, never as -H "Authorization: ..." on the command line.
 TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml 2>/dev/null | awk '{print $2}')}"
 if [ -z "$TOKEN" ]; then
   echo "No Zeabur token found — set ZEABUR_API_KEY or run: npx zeabur@latest auth login" >&2
@@ -106,41 +110,40 @@ chmod 600 "$ZAPI_CFG"
 trap 'rm -f "$ZAPI_CFG"' EXIT
 printf 'header = "Authorization: Bearer %s"\n' "$TOKEN" > "$ZAPI_CFG"
 unset TOKEN
+
+zapi() {
+  curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
+    -H "Content-Type: application/json" -d "$1"
+}
+
+# Start the install. This returns immediately — the work runs in the background.
+zapi "{\"query\":\"mutation(\$id: ObjectID!) { installK3s(serverID: \$id) }\",\"variables\":{\"id\":\"$SERVER_ID\"}}"
+
+# Wait for it: up to 15 minutes, checking every 30 seconds.
+for _ in $(seq 1 30); do
+  sleep 30
+  RESP=$(zapi "{\"query\":\"query(\$id: ObjectID!) { server(_id: \$id) { hasK3s provisioningStatus } }\",\"variables\":{\"id\":\"$SERVER_ID\"}}")
+  HAS_K3S=$(printf '%s' "$RESP" | jq -r '.data.server.hasK3s')
+  STATUS=$(printf '%s' "$RESP" | jq -r '.data.server.provisioningStatus')
+  echo "hasK3s=$HAS_K3S provisioningStatus=$STATUS"
+  if [ "$HAS_K3S" = "true" ]; then echo "ZeaburOS is installed"; exit 0; fi
+  if [ "$STATUS" = "FAILED" ]; then echo "Install failed: $RESP" >&2; exit 1; fi
+done
+echo "Still installing after 15 minutes — check the server's page in the dashboard" >&2
+exit 2
 ```
 
-- Prefer the `ZEABUR_API_KEY` environment variable if set
-- Otherwise reuse the CLI token from `~/.config/zeabur/cli.yaml` (present after `npx zeabur@latest auth login` — use the `zeabur-auth` skill if the user is not logged in)
-- **Stop if no token was found.** Continuing sends an unauthenticated request, and the resulting `401` reads as "the server is broken" rather than "you are not logged in"
-- Each tool/Bash invocation is a fresh shell — run this setup in the same shell block as the requests that use `$ZAPI_CFG`. The `trap` removes the config even if a command in between fails
+Why each part is the way it is:
 
-### Start the install
+- **The mutation returning does not mean the install finished.** The work runs in the background — SSH into the machine, install k3s, wait for the node to come up — and takes several minutes. A `true` response only means it was accepted and started. Never report success off the mutation alone.
+- **Success is `hasK3s: true`, not `provisioningStatus: "READY"`.** The status goes `READY` → `INITIALIZING` → `READY`, so `READY` is also the state *before* the install starts. Polling for it reports success the moment you look too early — and it will look right, because the machine really is `READY`.
+- **`FAILED` is checked separately**, so a broken install ends the wait instead of running out the clock.
+- **Parse with `jq`, not by grepping the raw JSON.** `grep '"hasK3s":true'` breaks the moment the response is formatted with a space after the colon, and it fails *open* — a missed match looks like "still installing".
+- **The wait is bounded.** After 15 minutes, stop and report the current state rather than polling forever; the server's page in the dashboard shows progress detail.
+- **Stop if no token was found.** Continuing sends an unauthenticated request, and the resulting `401` reads as "the server is broken" rather than "you are not logged in".
+- **The `trap` removes the curl config** even if a command in between fails. Each tool/Bash invocation is a fresh shell, so keep the whole block together — `$ZAPI_CFG` does not survive into the next one.
 
-```bash
-curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
-  -H "Content-Type: application/json" \
-  -d '{"query":"mutation($id: ObjectID!) { installK3s(serverID: $id) }","variables":{"id":"<server-id>"}}'
-```
-
-**Returning does not mean the install finished.** The work runs in the background — SSH into the machine, install k3s, wait for the node to come up — and takes several minutes. A `true` response only means the install was accepted and started.
-
-### Poll until it finishes
-
-```bash
-curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
-  -H "Content-Type: application/json" \
-  -d '{"query":"query($id: ObjectID!) { server(_id: $id) { hasK3s provisioningStatus } }","variables":{"id":"<server-id>"}}'
-```
-
-Poll every ~30 seconds and stop on one of:
-
-| Condition | Meaning |
-|-----------|---------|
-| `hasK3s: true` | **Done.** The server runs ZeaburOS and can host projects. |
-| `provisioningStatus: "FAILED"` | The install failed. Report it; do not blind-retry. |
-
-**Watch `hasK3s`, not `provisioningStatus: "READY"`.** The status goes `READY` → `INITIALIZING` → `READY`, so `READY` is also the state *before* the install starts — polling for it reports success the moment you look too early.
-
-**Bound the wait.** If it has not converged after ~15 minutes, stop polling and report the current state instead of waiting forever; the server's page in the Zeabur dashboard shows progress detail.
+Prefer `ZEABUR_API_KEY` if it is set; otherwise the token comes from `~/.config/zeabur/cli.yaml`, written by `npx zeabur@latest auth login` (use the `zeabur-auth` skill if the user is not logged in).
 
 ### Errors
 

--- a/skills/zeabur-server-rent/SKILL.md
+++ b/skills/zeabur-server-rent/SKILL.md
@@ -98,6 +98,8 @@ One block: authenticate, start the install, wait for it. Substitute the server I
 ```bash
 SERVER_ID="<server-id>"
 
+command -v jq >/dev/null 2>&1 || { echo "jq is required to read the API responses" >&2; exit 1; }
+
 # Keep the token out of the process list: write it into a 0600 curl config
 # passed with -K, never as -H "Authorization: ..." on the command line.
 TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml 2>/dev/null | awk '{print $2}')}"
@@ -116,15 +118,27 @@ zapi() {
     -H "Content-Type: application/json" -d "$1"
 }
 
-# Start the install. This returns immediately — the work runs in the background.
-zapi "{\"query\":\"mutation(\$id: ObjectID!) { installK3s(serverID: \$id) }\",\"variables\":{\"id\":\"$SERVER_ID\"}}"
+# GraphQL reports failures as HTTP 200 with an `errors` array, so a request that
+# "succeeded" can still be a hard failure. Stop on one instead of polling past it.
+die_on_error() {
+  if printf '%s' "$1" | jq -e 'has("errors")' >/dev/null 2>&1; then
+    printf '%s' "$1" | jq -r '.errors[] | "\(.extensions.code // "ERROR"): \(.message)\(if .extensions.description then " — " + .extensions.description else "" end)"' >&2
+    exit 1
+  fi
+}
 
-# Wait for it: up to 15 minutes, checking every 30 seconds.
-for _ in $(seq 1 30); do
+# Start the install. This returns immediately — the work runs in the background.
+RESP=$(zapi "{\"query\":\"mutation(\$id: ObjectID!) { installK3s(serverID: \$id) }\",\"variables\":{\"id\":\"$SERVER_ID\"}}")
+die_on_error "$RESP"
+
+# Wait for it, against a real 15-minute deadline.
+DEADLINE=$(( $(date +%s) + 900 ))
+while [ "$(date +%s)" -lt "$DEADLINE" ]; do
   sleep 30
   RESP=$(zapi "{\"query\":\"query(\$id: ObjectID!) { server(_id: \$id) { hasK3s provisioningStatus } }\",\"variables\":{\"id\":\"$SERVER_ID\"}}")
-  HAS_K3S=$(printf '%s' "$RESP" | jq -r '.data.server.hasK3s')
-  STATUS=$(printf '%s' "$RESP" | jq -r '.data.server.provisioningStatus')
+  die_on_error "$RESP"
+  HAS_K3S=$(printf '%s' "$RESP" | jq -r '.data.server.hasK3s // "unknown"')
+  STATUS=$(printf '%s' "$RESP" | jq -r '.data.server.provisioningStatus // "unknown"')
   echo "hasK3s=$HAS_K3S provisioningStatus=$STATUS"
   if [ "$HAS_K3S" = "true" ]; then echo "ZeaburOS is installed"; exit 0; fi
   if [ "$STATUS" = "FAILED" ]; then echo "Install failed: $RESP" >&2; exit 1; fi
@@ -138,8 +152,9 @@ Why each part is the way it is:
 - **The mutation returning does not mean the install finished.** The work runs in the background — SSH into the machine, install k3s, wait for the node to come up — and takes several minutes. A `true` response only means it was accepted and started. Never report success off the mutation alone.
 - **Success is `hasK3s: true`, not `provisioningStatus: "READY"`.** The status goes `READY` → `INITIALIZING` → `READY`, so `READY` is also the state *before* the install starts. Polling for it reports success the moment you look too early — and it will look right, because the machine really is `READY`.
 - **`FAILED` is checked separately**, so a broken install ends the wait instead of running out the clock.
-- **Parse with `jq`, not by grepping the raw JSON.** `grep '"hasK3s":true'` breaks the moment the response is formatted with a space after the colon, and it fails *open* — a missed match looks like "still installing".
-- **The wait is bounded.** After 15 minutes, stop and report the current state rather than polling forever; the server's page in the dashboard shows progress detail.
+- **Every response is checked for `errors` first.** GraphQL returns failures as HTTP 200 with an `errors` array and no `data`, so an unauthorized token, a bad server ID, or any of the precondition failures below would otherwise read as "still installing" and burn the full 15 minutes before reporting nothing useful. `extensions.code` is the machine-readable code from the table below; `extensions.description` is the user-facing explanation.
+- **Parse with `jq`, not by grepping the raw JSON.** `grep '"hasK3s":true'` breaks the moment the response is formatted with a space after the colon, and it fails *open* — a missed match looks like "still installing". For the same reason the block refuses to start without `jq` rather than silently mis-parsing.
+- **The wait is a deadline, not a counter.** `30 × sleep 30` runs past 15 minutes once request time is added; comparing against a timestamp means the stated bound is the real one.
 - **Stop if no token was found.** Continuing sends an unauthenticated request, and the resulting `401` reads as "the server is broken" rather than "you are not logged in".
 - **The `trap` removes the curl config** even if a command in between fails. Each tool/Bash invocation is a fresh shell, so keep the whole block together — `$ZAPI_CFG` does not survive into the next one.
 

--- a/skills/zeabur-server-rent/SKILL.md
+++ b/skills/zeabur-server-rent/SKILL.md
@@ -91,11 +91,15 @@ Works on any server that has no Zeabur services yet: one just rented, one reinst
 
 > **Not in the Zeabur CLI yet** — call the Zeabur GraphQL API directly at `https://api.zeabur.com/graphql`.
 
-### Authentication
+### Run this
 
-Keep the token out of the process list — write it into a `0600` curl config and pass that with `-K`, instead of putting `-H "Authorization: ..."` on the command line:
+One block: authenticate, start the install, wait for it. Substitute the server ID and run it as-is — every part of it is load-bearing, and the notes below say why.
 
 ```bash
+SERVER_ID="<server-id>"
+
+# Keep the token out of the process list: write it into a 0600 curl config
+# passed with -K, never as -H "Authorization: ..." on the command line.
 TOKEN="${ZEABUR_API_KEY:-$(grep '^token:' ~/.config/zeabur/cli.yaml 2>/dev/null | awk '{print $2}')}"
 if [ -z "$TOKEN" ]; then
   echo "No Zeabur token found — set ZEABUR_API_KEY or run: npx zeabur@latest auth login" >&2
@@ -106,41 +110,40 @@ chmod 600 "$ZAPI_CFG"
 trap 'rm -f "$ZAPI_CFG"' EXIT
 printf 'header = "Authorization: Bearer %s"\n' "$TOKEN" > "$ZAPI_CFG"
 unset TOKEN
+
+zapi() {
+  curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
+    -H "Content-Type: application/json" -d "$1"
+}
+
+# Start the install. This returns immediately — the work runs in the background.
+zapi "{\"query\":\"mutation(\$id: ObjectID!) { installK3s(serverID: \$id) }\",\"variables\":{\"id\":\"$SERVER_ID\"}}"
+
+# Wait for it: up to 15 minutes, checking every 30 seconds.
+for _ in $(seq 1 30); do
+  sleep 30
+  RESP=$(zapi "{\"query\":\"query(\$id: ObjectID!) { server(_id: \$id) { hasK3s provisioningStatus } }\",\"variables\":{\"id\":\"$SERVER_ID\"}}")
+  HAS_K3S=$(printf '%s' "$RESP" | jq -r '.data.server.hasK3s')
+  STATUS=$(printf '%s' "$RESP" | jq -r '.data.server.provisioningStatus')
+  echo "hasK3s=$HAS_K3S provisioningStatus=$STATUS"
+  if [ "$HAS_K3S" = "true" ]; then echo "ZeaburOS is installed"; exit 0; fi
+  if [ "$STATUS" = "FAILED" ]; then echo "Install failed: $RESP" >&2; exit 1; fi
+done
+echo "Still installing after 15 minutes — check the server's page in the dashboard" >&2
+exit 2
 ```
 
-- Prefer the `ZEABUR_API_KEY` environment variable if set
-- Otherwise reuse the CLI token from `~/.config/zeabur/cli.yaml` (present after `npx zeabur@latest auth login` — use the `zeabur-auth` skill if the user is not logged in)
-- **Stop if no token was found.** Continuing sends an unauthenticated request, and the resulting `401` reads as "the server is broken" rather than "you are not logged in"
-- Each tool/Bash invocation is a fresh shell — run this setup in the same shell block as the requests that use `$ZAPI_CFG`. The `trap` removes the config even if a command in between fails
+Why each part is the way it is:
 
-### Start the install
+- **The mutation returning does not mean the install finished.** The work runs in the background — SSH into the machine, install k3s, wait for the node to come up — and takes several minutes. A `true` response only means it was accepted and started. Never report success off the mutation alone.
+- **Success is `hasK3s: true`, not `provisioningStatus: "READY"`.** The status goes `READY` → `INITIALIZING` → `READY`, so `READY` is also the state *before* the install starts. Polling for it reports success the moment you look too early — and it will look right, because the machine really is `READY`.
+- **`FAILED` is checked separately**, so a broken install ends the wait instead of running out the clock.
+- **Parse with `jq`, not by grepping the raw JSON.** `grep '"hasK3s":true'` breaks the moment the response is formatted with a space after the colon, and it fails *open* — a missed match looks like "still installing".
+- **The wait is bounded.** After 15 minutes, stop and report the current state rather than polling forever; the server's page in the dashboard shows progress detail.
+- **Stop if no token was found.** Continuing sends an unauthenticated request, and the resulting `401` reads as "the server is broken" rather than "you are not logged in".
+- **The `trap` removes the curl config** even if a command in between fails. Each tool/Bash invocation is a fresh shell, so keep the whole block together — `$ZAPI_CFG` does not survive into the next one.
 
-```bash
-curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
-  -H "Content-Type: application/json" \
-  -d '{"query":"mutation($id: ObjectID!) { installK3s(serverID: $id) }","variables":{"id":"<server-id>"}}'
-```
-
-**Returning does not mean the install finished.** The work runs in the background — SSH into the machine, install k3s, wait for the node to come up — and takes several minutes. A `true` response only means the install was accepted and started.
-
-### Poll until it finishes
-
-```bash
-curl -sS --max-time 30 -K "$ZAPI_CFG" https://api.zeabur.com/graphql \
-  -H "Content-Type: application/json" \
-  -d '{"query":"query($id: ObjectID!) { server(_id: $id) { hasK3s provisioningStatus } }","variables":{"id":"<server-id>"}}'
-```
-
-Poll every ~30 seconds and stop on one of:
-
-| Condition | Meaning |
-|-----------|---------|
-| `hasK3s: true` | **Done.** The server runs ZeaburOS and can host projects. |
-| `provisioningStatus: "FAILED"` | The install failed. Report it; do not blind-retry. |
-
-**Watch `hasK3s`, not `provisioningStatus: "READY"`.** The status goes `READY` → `INITIALIZING` → `READY`, so `READY` is also the state *before* the install starts — polling for it reports success the moment you look too early.
-
-**Bound the wait.** If it has not converged after ~15 minutes, stop polling and report the current state instead of waiting forever; the server's page in the Zeabur dashboard shows progress detail.
+Prefer `ZEABUR_API_KEY` if it is set; otherwise the token comes from `~/.config/zeabur/cli.yaml`, written by `npx zeabur@latest auth login` (use the `zeabur-auth` skill if the user is not logged in).
 
 ### Errors
 


### PR DESCRIPTION
## Background

An end-to-end run of *"rent me a server, I want to deploy my project"* got the hard part right: the agent polled `hasK3s` rather than `provisioningStatus: "READY"` (the trap — `READY` is also the state *before* the install starts), bounded the wait at 15 minutes, and treated `FAILED` as terminal.

But the loop it wrote to do that came out worse than the skill's own rules in two ways:

- **The token setup lost its empty-token guard**, which the skill does specify. Unauthenticated, the resulting `401` reads as "the server is broken" rather than "you are not logged in".
- **Completion was detected with `grep '"hasK3s":true'`** on the raw response. That breaks as soon as the JSON is formatted with a space after the colon — and it fails *open*: a missed match is indistinguishable from "still installing", so the install silently runs to the timeout and reports as stuck.

Neither is a rule the agent ignored. The skill simply never showed a working poll, so authentication, the mutation and the wait had to be stitched together from three separate fragments.

## Change

Those three fragments become **one block** to substitute a server ID into and run — authenticate, start the install, wait — followed by notes on why each part is load-bearing rather than incidental:

- the mutation returning is not completion;
- success is `hasK3s: true`, not `provisioningStatus: "READY"`;
- `FAILED` is checked separately so a broken install ends the wait instead of running out the clock;
- parse with `jq`, because grepping raw JSON fails open;
- the wait is bounded;
- stop when no token is found;
- the `trap` removes the curl config even if something in between fails.

## Verification

The parsing was checked against every state the loop can observe:

| Response | Result |
|---|---|
| `{"hasK3s":true,...}` (compact) | done |
| `{ "hasK3s": true, ... }` (spaces after colons) | done — **the case the old grep missed** |
| `hasK3s: false`, `provisioningStatus: "READY"` (pre-install) | keep waiting |
| `hasK3s: false`, `provisioningStatus: "INITIALIZING"` | keep waiting |
| `provisioningStatus: "FAILED"` | fail |

Block also passes `bash -n`.

## Notes

- `plugins/zeabur/` regenerated with `node scripts/sync-codex-plugin.mjs`.
- Version bumped to **1.21.2** across all three manifests, with a README changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787305422&installation_model_id=20298&pr_number=78&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F78&signature=39aa21f756a9b3f269d5babac9ab50066053ec9272cb8ff363c74ab394b6172c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version 1.21.2 across the available plugins.

* **Documentation**
  * Simplified ZeaburOS installation into one copy-pasteable command block.
  * Added clearer authentication, installation progress, success, failure, and timeout handling.
  * Improved status parsing and temporary credential cleanup guidance.
  * Updated the README with the 1.21.2 changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->