### PR TITLE
fix(skills): warn that converting to ZeaburOS reinstalls and wipes the disk

### DIFF
--- a/plugins/zeabur/skills/zeabur-server-list/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-list/SKILL.md
@@ -59,6 +59,8 @@ A server can host Zeabur projects **only once it runs ZeaburOS**. A project's `R
 
 Renting provisions **Ubuntu** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until ZeaburOS is installed on it. The `zeabur-server-rent` skill covers that step. Which kind a given server is, is answered by the **OS** column above.
 
+> Installing directly is only for a machine that is still blank. On one the user has already set up, converting means **reinstalling** it in the dashboard, which **erases the disk** — see the `zeabur-server-rent` skill before suggesting it.
+
 **On a ZeaburOS server:**
 
 - **To deploy a service**, use the `zeabur-deploy` skill with the project bound to that server — do NOT SSH in and manually set up web servers or copy files.

--- a/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
+++ b/plugins/zeabur/skills/zeabur-server-rent/SKILL.md
@@ -87,7 +87,15 @@ Follow "Install ZeaburOS on a server" below. If they chose Ubuntu, you are done 
 
 ## Install ZeaburOS on a server
 
-Works on any server that has no Zeabur services yet: one just rented, one reinstalled back to base OS, or a WonderMesh device that stopped at joining the mesh.
+**Only on a machine that is still blank** — one just rented, one just reinstalled back to base OS, or a WonderMesh device that stopped at joining the mesh. This installs k3s *on top of* the running system without wiping it: safe on an empty machine, unpredictable on one that is already in use.
+
+> **Do not run this on a machine the user has set up.** k3s claims ports (6443, the NodePort range, NATS on 4222), rewrites iptables rules, and brings its own container runtime alongside any Docker already there. On a box running docker compose, 1Panel, 寶塔 or similar, whether the install succeeds depends on what is already installed — and it can break what is running.
+>
+> For those machines, send the user to the dashboard instead: the server's **Settings → Danger Zone → Reinstall OS**, choosing ZeaburOS. Reinstalling makes the result predictable, **and it erases the disk**. Say that plainly and tell them to back up first — it is their call to make, not yours.
+>
+> Switching is destructive in **both** directions. ZeaburOS → standard distribution and standard distribution → ZeaburOS are both a reinstall, and both wipe the machine.
+
+If the machine is blank, run this.
 
 > **Not in the Zeabur CLI yet** — call the Zeabur GraphQL API directly at `https://api.zeabur.com/graphql`.
 

--- a/skills/zeabur-server-list/SKILL.md
+++ b/skills/zeabur-server-list/SKILL.md
@@ -59,6 +59,8 @@ A server can host Zeabur projects **only once it runs ZeaburOS**. A project's `R
 
 Renting provisions **Ubuntu** — base OS and SSH, no Zeabur services — so a newly rented server cannot host projects until ZeaburOS is installed on it. The `zeabur-server-rent` skill covers that step. Which kind a given server is, is answered by the **OS** column above.
 
+> Installing directly is only for a machine that is still blank. On one the user has already set up, converting means **reinstalling** it in the dashboard, which **erases the disk** — see the `zeabur-server-rent` skill before suggesting it.
+
 **On a ZeaburOS server:**
 
 - **To deploy a service**, use the `zeabur-deploy` skill with the project bound to that server — do NOT SSH in and manually set up web servers or copy files.

--- a/skills/zeabur-server-rent/SKILL.md
+++ b/skills/zeabur-server-rent/SKILL.md
@@ -87,7 +87,15 @@ Follow "Install ZeaburOS on a server" below. If they chose Ubuntu, you are done 
 
 ## Install ZeaburOS on a server
 
-Works on any server that has no Zeabur services yet: one just rented, one reinstalled back to base OS, or a WonderMesh device that stopped at joining the mesh.
+**Only on a machine that is still blank** — one just rented, one just reinstalled back to base OS, or a WonderMesh device that stopped at joining the mesh. This installs k3s *on top of* the running system without wiping it: safe on an empty machine, unpredictable on one that is already in use.
+
+> **Do not run this on a machine the user has set up.** k3s claims ports (6443, the NodePort range, NATS on 4222), rewrites iptables rules, and brings its own container runtime alongside any Docker already there. On a box running docker compose, 1Panel, 寶塔 or similar, whether the install succeeds depends on what is already installed — and it can break what is running.
+>
+> For those machines, send the user to the dashboard instead: the server's **Settings → Danger Zone → Reinstall OS**, choosing ZeaburOS. Reinstalling makes the result predictable, **and it erases the disk**. Say that plainly and tell them to back up first — it is their call to make, not yours.
+>
+> Switching is destructive in **both** directions. ZeaburOS → standard distribution and standard distribution → ZeaburOS are both a reinstall, and both wipe the machine.
+
+If the machine is blank, run this.
 
 > **Not in the Zeabur CLI yet** — call the Zeabur GraphQL API directly at `https://api.zeabur.com/graphql`.
 


### PR DESCRIPTION
跟進 ZEA-10209（dashboard [#1739](https://github.com/zeabur/dashboard/pull/1739)）。

## 問題

`zeabur-server-rent` 的「Install ZeaburOS on a server」寫著：

> Works on any server that has no Zeabur services yet

然後直接給一段呼叫 `installK3s` GraphQL mutation 的腳本。對 agent 來說這是一張通行證 —— 只要 `hasK3s === false` 就可以打下去，包括**使用者已經拿來跑東西的機器**。

在那種機器上就地裝 k3s 會撞埠（6443 / NodePort / NATS 4222）、改寫 iptables、跟既有的 Docker 併存兩套 container runtime。成不成功取決於那台機器原本裝了什麼，而且可能弄壞正在跑的服務。

而且原文完全沒提資料風險 —— dashboard 那邊轉換已經改成重裝了，會清空磁碟。

## 改動

**`zeabur-server-rent`** —— 把 API 路徑的適用範圍收窄成「還是空的機器」（剛租完、剛重裝完、WonderMesh 剛加入），並加上：

- 為什麼不能在使用者已經設定過的機器上跑（具體講埠、iptables、runtime）
- 那種機器要引導去 dashboard 的 **Settings → Danger Zone → Reinstall OS** 選 ZeaburOS
- **重裝會清空磁碟**，要明說並要使用者先備份，而且**這是使用者的決定，不是 agent 的**
- 切換**兩個方向都是重裝、都會抹碟**

**`zeabur-server-list`** —— 補一句，避免 agent 讀完這份就去建議「裝一下 ZeaburOS 就好」而不知道代價。

`skills/` 與 `plugins/zeabur/skills/` 兩棵樹同步更新，已驗證內容一致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787309184&installation_model_id=20298&pr_number=79&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F79&signature=b5c45aa915b8001b6cd5052d24f79b2eb8d13152a9f7b17f5dff689b885bb215"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that direct ZeaburOS installation is intended only for blank machines.
  * Added warnings against installing on already-configured servers due to destructive system changes.
  * Documented the dashboard-based OS reinstall flow for existing setups, including the warning that it erases the disk.
  * Added guidance to review server rental instructions before recommending installation or conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->