### PR TITLE
fix(skills): route Wonder Mesh domain setup through the Dashboard Domains tab

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "zeabur",
   "description": "Zeabur CLI skills for deployment, template management, and troubleshooting",
-  "version": "1.21.2",
+  "version": "1.21.3",
   "author": {
     "name": "Can"
   },

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "zeabur",
-  "version": "1.21.2",
+  "version": "1.21.3",
   "description": "Zeabur CLI skills for deployment, template management, server management, and troubleshooting",
   "author": {
     "name": "Zeabur",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Agent skills for Zeabur CLI operations, deployment, and troubleshooting. Works with **Claude Code**, **OpenAI Codex**, and other agents supporting the SKILL.md format.
 
-**Current version: 1.21.2**
+**Current version: 1.21.3**
 
 ## Installation
 
@@ -64,6 +64,10 @@ codex --plugin-dir /path/to/agent-skills
 | `zeabur-domain-registrant` | Manage registrant profiles for domain registration | Creating/updating contact info for domains |
 
 ## Changelog
+
+### 1.21.3
+
+- Improved `zeabur-domain-url` — documented the `WONDER_MESH_SERVER_REQUIRES_GATEWAY` rejection for services on Wonder Mesh provider servers: stop retrying `domain create`, don't bind the domain to the app or gateway service directly, and send the user to the service's **Domains** tab in the Dashboard, which runs the gateway attach flow (binding to `app-gateway` in `wonder-mesh-gateway-{wonderNetID}`)
 
 ### 1.21.2
 

--- a/skills/zeabur-domain-url/SKILL.md
+++ b/skills/zeabur-domain-url/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zeabur-domain-url
-description: Use when services need public URL for redirects or CORS. Use when WEB_URL or similar has trailing slash issues. Use when user reports "redirect goes to wrong URL", "CORS error", or "trailing slash problem". Also use when user says "add domain", "set up domain", "bind domain", "create domain", or "manage domains" for a Zeabur service.
+description: Use when services need public URL for redirects or CORS. Use when WEB_URL or similar has trailing slash issues. Use when user reports "redirect goes to wrong URL", "CORS error", or "trailing slash problem". Also use when user says "add domain", "set up domain", "bind domain", "create domain", or "manage domains" for a Zeabur service. Also use when domain creation fails with "WONDER_MESH_SERVER_REQUIRES_GATEWAY" or a domain is stuck in PROVISIONING on a Wonder Mesh server.
 ---
 
 # Zeabur Domain URL Configuration
@@ -99,6 +99,30 @@ Value: <server IP from above>
 ```bash
 npx zeabur@latest domain delete --id <service-id> --domain <domain> -y -i=false
 ```
+
+### Wonder Mesh servers: `WONDER_MESH_SERVER_REQUIRES_GATEWAY`
+
+Domains cannot be bound directly to a service running on a Wonder Mesh provider server. Any flow that creates a domain — `domain create`, automatic domain binding during deploy, template deploy, or PR preview — can be rejected with:
+
+```
+Error: WONDER_MESH_SERVER_REQUIRES_GATEWAY
+```
+
+This is **not** a port or networking misconfiguration on the service, and no CLI retry can succeed. The backend rejects the request because a domain bound directly to the app service would be stuck in `PROVISIONING` forever. Domains for these services must be attached through the Wonder Mesh gateway, and that flow only exists in the Zeabur Dashboard.
+
+When you receive this error:
+
+1. **Stop.** Do not retry `domain create` — not with the same arguments, different flags, a changed port config, or a different service ID.
+2. **Send the user to the Dashboard.** Tell them to open the service in the Zeabur Dashboard and set up the domain from its **Domains** tab.
+3. **Explain what the Dashboard does.** The Domains tab runs the Wonder Mesh gateway attach flow: it binds the domain to the `app-gateway` service in the `wonder-mesh-gateway-{wonderNetID}` project on the user's behalf. This is the only supported path.
+
+Do **not**:
+
+- Bind the domain directly to the Wonder Mesh app service via CLI or API
+- Bind the domain to the gateway service yourself with `domain create`
+- Use any CLI / MCP "gateway attach" command — none exists
+
+Services on all other servers are unaffected: the generated domain and custom domain flows above work unchanged.
 
 ### Caution
 

--- a/skills/zeabur-domain-url/SKILL.md
+++ b/skills/zeabur-domain-url/SKILL.md
@@ -104,7 +104,7 @@ npx zeabur@latest domain delete --id <service-id> --domain <domain> -y -i=false
 
 Domains cannot be bound directly to a service running on a Wonder Mesh provider server. Any flow that creates a domain — `domain create`, automatic domain binding during deploy, template deploy, or PR preview — can be rejected with:
 
-```
+```text
 Error: WONDER_MESH_SERVER_REQUIRES_GATEWAY
 ```
 


### PR DESCRIPTION
## Summary

- Domain creation for services running on **Wonder Mesh** provider servers is now rejected by the backend with `WONDER_MESH_SERVER_REQUIRES_GATEWAY` (see `backend#2341`). A domain bound directly to such a service would stay stuck in `PROVISIONING` forever, so the gateway attach flow — which only exists in the Zeabur Dashboard — is the only supported path.
- Previously `zeabur-domain-url` documented only the generic `domain create` flow. When an agent hit this error it had no correct guidance, so it tended to misdiagnose the rejection as a port problem, retry the forbidden command, or dead-end at "contact support".
- This PR adds a dedicated section to `zeabur-domain-url` that: tells the agent to stop retrying, forbids binding the domain to the app service or the gateway service directly (no CLI/MCP "gateway attach" command exists), and routes the user to the service's **Domains** tab in the Dashboard, explaining that it binds the domain to `app-gateway` in the `wonder-mesh-gateway-{wonderNetID}` project. The frontmatter description gains the error keyword for discovery.
- Generated-domain and custom-domain flows for services on all other servers are unchanged. Bumps the plugin to `1.21.3` across both manifests and the README, with a changelog entry.

## Test plan

- [x] Verified with before/after subagent scenarios (generated domain, custom domain under time pressure, and template auto-bind with a tempting `app-gateway` project visible). Baseline agents misdiagnosed the error or retried the forbidden command; with the new section, all three route the user to the Dashboard Domains tab and never retry `domain create`.
- [x] Confirmed the generated-domain and custom-domain CLI instructions are untouched.
- [x] Validated both `plugin.json` manifests parse as JSON and version numbers match across `.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, and the README.

Refs: DES-839, PLA-2126

Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/zeabur/codesmith/agent-skills/pr/80"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787462060&installation_model_id=20298&pr_number=80&repository=zeabur%2Fagent-skills&return_to=https%3A%2F%2Fgithub.com%2Fzeabur%2Fagent-skills%2Fpull%2F80&signature=05cb3fd5c4ec353e65e840885f8b1c6bcee9a99d04383f533517468cdfbcb988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guidance for handling Wonder Mesh domain setup through the Zeabur Dashboard’s Domains tab.

* **Bug Fixes**
  * Clarified that unsupported direct domain binding and repeated CLI retries should be avoided for Wonder Mesh services.
  * Added troubleshooting guidance for public URL redirects, CORS, trailing slashes, and domains stuck in provisioning.

* **Documentation**
  * Updated plugin and documented skill versions from 1.21.2 to 1.21.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->